### PR TITLE
Feat: 회원가입 입력 form 구현

### DIFF
--- a/src/components/features/SignUp/SignUpForm.jsx
+++ b/src/components/features/SignUp/SignUpForm.jsx
@@ -1,0 +1,5 @@
+const SignUpForm = () => {
+  return <div>SignUpForm</div>;
+};
+
+export default SignUpForm;

--- a/src/components/features/SignUp/SignUpForm.jsx
+++ b/src/components/features/SignUp/SignUpForm.jsx
@@ -1,5 +1,107 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+import { color } from '../../../styles/color';
+import { fontSize } from '../../../styles/fontSize';
+import { Link } from 'react-router-dom';
+
 const SignUpForm = () => {
-  return <div>SignUpForm</div>;
+  const [userInfo, setUserInfo] = useState({
+    email: '',
+    password: '',
+    nickName: ''
+  });
+
+  const handleChange = (e) => {
+    const { id, value } = e.target;
+    setUserInfo({ ...userInfo, [id]: value });
+  };
+  return (
+    <StWrapper>
+      <form>
+        <StSignUpContainer>
+          <h2>사이트명</h2>
+          <StInput type="email" id="email" placeholder="이메일 입력" value={userInfo.email} onChange={handleChange} />
+          <StInput
+            type="password"
+            id="password"
+            placeholder="비밀번호 입력"
+            value={userInfo.password}
+            onChange={handleChange}
+          />
+          <StInput
+            type="text"
+            id="nickName"
+            placeholder="닉네임 입력"
+            value={userInfo.nickName}
+            onChange={handleChange}
+          />
+          <StSignButton>가입하기</StSignButton>
+        </StSignUpContainer>
+      </form>
+      <StLoginBox>
+        <p style={{ fontSize: `${fontSize.medium}` }}>계정이 있으신가요?</p>
+        <Link to={'/login'} style={{ color: `${color.main}` }}>
+          로그인 하러 가기
+        </Link>
+      </StLoginBox>
+    </StWrapper>
+  );
 };
 
 export default SignUpForm;
+
+/** styled component */
+const StWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  gap: 10px;
+`;
+
+const StSignUpContainer = styled.div`
+  width: 400px;
+  height: 300px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  border: 1px solid ${color.gray};
+  border-radius: 5px;
+`;
+
+const StInput = styled.input`
+  width: 300px;
+  height: 40px;
+  border-radius: 5px;
+  border: 1px solid ${color.gray};
+  padding: 5px 10px 5px 10px;
+  font-size: ${fontSize.medium};
+  box-sizing: border-box;
+
+  &:hover {
+    border: 1px solid #484c50;
+  }
+`;
+
+const StSignButton = styled.button`
+  width: 300px;
+  height: 40px;
+  border-radius: 5px;
+  border: none;
+  font-size: ${fontSize.medium};
+  color: ${color.white};
+  background-color: ${color.main};
+  cursor: pointer;
+
+  &:hover {
+    background-color: #cd5200;
+  }
+`;
+
+const StLoginBox = styled(StSignUpContainer)`
+  height: 100px;
+  gap: 15px;
+`;

--- a/src/components/features/SignUp/SignUpForm.jsx
+++ b/src/components/features/SignUp/SignUpForm.jsx
@@ -59,7 +59,7 @@ const SignUpForm = () => {
         throw userError;
       }
 
-      setUserInfo({ email: '', password: '', nickName: '' });
+      setUserInfo({ email: '', password: '', passwordCheck: '', nickName: '' });
 
       alert('회원가입이 완료되었습니다.');
       navigate('/login');

--- a/src/components/features/SignUp/SignUpForm.jsx
+++ b/src/components/features/SignUp/SignUpForm.jsx
@@ -71,9 +71,9 @@ const SignUpForm = () => {
 
   /** UI */
   return (
-    <StWrapper>
+    <StContainer>
       <form onSubmit={handleSignUp}>
-        <StSignUpContainer>
+        <StSignUpWrapper>
           <h2>사이트명</h2>
           <StInput type="email" id="email" placeholder="이메일 입력" value={userInfo.email} onChange={handleChange} />
           <StInput
@@ -98,22 +98,22 @@ const SignUpForm = () => {
             onChange={handleChange}
           />
           <StSignButton>가입하기</StSignButton>
-        </StSignUpContainer>
+        </StSignUpWrapper>
       </form>
-      <StLoginBox>
+      <StLoginWrapper>
         <p style={{ fontSize: `${fontSize.medium}` }}>계정이 있으신가요?</p>
         <Link to={'/login'} style={{ color: `${color.main}` }}>
           로그인 하러 가기
         </Link>
-      </StLoginBox>
-    </StWrapper>
+      </StLoginWrapper>
+    </StContainer>
   );
 };
 
 export default SignUpForm;
 
 /** styled component */
-const StWrapper = styled.div`
+const StContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -122,7 +122,7 @@ const StWrapper = styled.div`
   gap: 10px;
 `;
 
-const StSignUpContainer = styled.div`
+const StSignUpWrapper = styled.div`
   width: 400px;
   height: 350px;
   display: flex;
@@ -163,7 +163,7 @@ const StSignButton = styled.button`
   }
 `;
 
-const StLoginBox = styled(StSignUpContainer)`
+const StLoginWrapper = styled(StSignUpWrapper)`
   height: 100px;
   gap: 15px;
 `;

--- a/src/components/features/SignUp/SignUpForm.jsx
+++ b/src/components/features/SignUp/SignUpForm.jsx
@@ -64,6 +64,7 @@ const SignUpForm = () => {
     }
   };
 
+  /** UI */
   return (
     <StWrapper>
       <form onSubmit={handleSignUp}>

--- a/src/components/features/SignUp/SignUpForm.jsx
+++ b/src/components/features/SignUp/SignUpForm.jsx
@@ -9,6 +9,7 @@ const SignUpForm = () => {
   const [userInfo, setUserInfo] = useState({
     email: '',
     password: '',
+    passwordCheck: '',
     nickName: ''
   });
 
@@ -33,6 +34,10 @@ const SignUpForm = () => {
     }
     if (userInfo.nickName === '') {
       alert('닉네임을 입력해주세요');
+      return;
+    }
+    if (userInfo.passwordCheck !== userInfo.password) {
+      alert('비밀번호가 동일하지 않습니다');
       return;
     }
 
@@ -79,6 +84,13 @@ const SignUpForm = () => {
             onChange={handleChange}
           />
           <StInput
+            type="password"
+            id="passwordCheck"
+            placeholder="비밀번호 확인"
+            value={userInfo.passwordCheck}
+            onChange={handleChange}
+          />
+          <StInput
             type="text"
             id="nickName"
             placeholder="닉네임 입력"
@@ -112,7 +124,7 @@ const StWrapper = styled.div`
 
 const StSignUpContainer = styled.div`
   width: 400px;
-  height: 300px;
+  height: 350px;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,10 +2,12 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.jsx';
 import { AuthProvider } from './context/AuthProvider.jsx';
+import { GlobalStyle } from './styles/GlobalStyle.jsx';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <AuthProvider>
+      <GlobalStyle />
       <App />
     </AuthProvider>
   </StrictMode>

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -1,5 +1,7 @@
+import SignUpForm from '../components/features/SignUp/SignUpForm';
+
 const SignUp = () => {
-  return <div>SignUp</div>;
+  return <SignUpForm />;
 };
 
 export default SignUp;


### PR DESCRIPTION
### 관련 이슈
회원가입 기능 PR을 완료하고, context API를 작성하려고 합니다.
그래서 아직 회원가입을 완료한 사용자의 id를 가져오는 로직이 없습니다!
회원가입 입력창에서 닉네임을 입력해도 supabase table에는 추가되지 않습니다!

### 작업 요약
supabase auth를 이용해서 회원가입하는 기능을 구현하였습니다.

**📍 이메일 입력** - 입력하지 않으면 경고창이 뜹니다.
**📍 비밀번호 입력** - 입력하지 않으면 경고창이 뜹니다.
**📍 비밀번호 확인** -  위에 입력한 비밀번호와 일치하지 않으면 경고창이 뜹니다.
**📍 닉네임 입력** - 입력하지 않으면 경고창이 뜹니다.

**가입하기 완료 버튼**을 누르면 로그인 화면으로 이동합니다.
=> supabase auth에 가입한 사용자 정보 뜨는 것까지 확인했습니다.

**로그인하러 가기 링크**를 누르면 로그인 화면으로 이동합니다.

### 리뷰 요구 사항
수정했으면 좋겠는 부분이 있으면 편하게 말씀해주세요!
코드에서 이해가 안가거나 변수명이 애매한 경우에도 말씀해주십쇼🫡

### 미리보기
![signup](https://github.com/user-attachments/assets/d5ec5073-62fd-4afe-a8e9-0a996cc684ba)
