### PR TITLE
Feat: 렌더링 기능 구현 / UI 요소 수정(width)

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,15 +1,39 @@
 import Header from '../components/layout/Header';
 import Sidebar from '../components/layout/SideBar';
 import styled from 'styled-components';
+import { supabase } from '../services/supabaseClient';
+import { useEffect, useState } from 'react';
 
 const Home = () => {
+  const [posts, setPosts] = useState([]);
+
+  // supabase - SELECT 함수 (getPost)
+  const getPost = async () => {
+    try {
+      const { data } = await supabase.from('posts').select();
+      setPosts(data);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    getPost();
+  }, []); // 초기 렌더링 시에만 데이터 fetch
+
   return (
     <StContainer>
       <Header />
       <StMainContent>
         <Sidebar />
         <StContentWrapper>
-          <div>Home</div>
+          <StPostWrapper>
+            {posts.map((post) => (
+              <div style={{ border: '1px solid black' }} key={post.id}>
+                <p>{post.title}</p>
+              </div>
+            ))}
+          </StPostWrapper>
         </StContentWrapper>
       </StMainContent>
     </StContainer>
@@ -31,4 +55,12 @@ const StMainContent = styled.main`
 
 const StContentWrapper = styled.div`
   padding: 10px;
+  width: 100%;
+`;
+
+const StPostWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 `;


### PR DESCRIPTION
### 관련 이슈
> Home 컴포넌트 내 콘텐츠가 사이드바에 가려지는 현상

[기존]
![스크린샷 2025-02-14 오후 5 45 51](https://github.com/user-attachments/assets/5dd3b5d9-9acf-46b6-990a-2a26fac7e92b)

### 작업 요약
> 피드 게시물이 올라갈 컨테이너 신규 생성 <StPostWrapper>
> <StPostWrapper>의 부모요소인 <StContentWrapper>의 width값 조정(100%)하여 사이드바에 가려지는 문제 해결

### 리뷰 요구 사항
> style은 간단하게 flex, 정렬 요소만 추가해 두었습니다. (+ 가시성 확보 목적 border 임시 세팅)
> supabase에서 데이터 불러오는 로직 중심으로 리뷰 요청드립니다.

### 미리보기
[수정]
![스크린샷 2025-02-14 오후 6 19 11](https://github.com/user-attachments/assets/2189629c-4198-41f3-bfc7-f698f99cbf88)
