### PR TITLE
Refactor/layout-base

### DIFF
--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -4,9 +4,11 @@ import { StCenterWrapper } from '../../styles/GlobalStyle';
 import { FaRegBell, FaUserCircle } from 'react-icons/fa';
 import { useNavigate } from 'react-router-dom';
 import { useHeader } from '../../context/components/header/useHeader';
+import { useAuth } from '../../context/auth/useAuth';
 
 const Header = () => {
-  const { isLoginOpen, setIsLoginOpen, loginModalRef } = useHeader();
+  const { isLoginOpen, setIsLoginOpen, loginModalRef, handleAuthAction } = useHeader();
+  const { isLogin } = useAuth();
   const navigate = useNavigate();
 
   return (
@@ -24,7 +26,7 @@ const Header = () => {
       {isLoginOpen && (
         <StModal ref={loginModalRef}>
           <StAccountName>계정</StAccountName>
-          <StButton onClick={() => navigate('/login')}>로그인</StButton>
+          <StButton onClick={handleAuthAction}>{isLogin ? '로그아웃' : '로그인'}</StButton>
           <StButton onClick={() => navigate('/mypage')}>프로필</StButton>
         </StModal>
       )}

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -2,33 +2,12 @@ import styled from 'styled-components';
 import { fontSize } from '../../styles/fontSize';
 import { StCenterWrapper } from '../../styles/GlobalStyle';
 import { FaRegBell, FaUserCircle } from 'react-icons/fa';
-import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useHeader } from '../../context/components/header/useHeader';
 
 const Header = () => {
-  const [isLoginOpen, setIsLoginOpen] = useState(false);
+  const { isLoginOpen, setIsLoginOpen, loginModalRef } = useHeader();
   const navigate = useNavigate();
-  const modalRef = useRef(null);
-
-  useEffect(() => {
-    const handleClickOutside = (event) => {
-      if (modalRef.current && !modalRef.current.contains(event.target)) {
-        setIsLoginOpen(false);
-      }
-    };
-
-    // 모달이 열린 상태에서만 외부 클릭 감지 활성화
-    if (isLoginOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
-    } else {
-      document.removeEventListener('mousedown', handleClickOutside);
-    }
-
-    // 언마운트되면 이벤트 리스너 제거
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [isLoginOpen]);
 
   return (
     <StContainer>
@@ -43,7 +22,7 @@ const Header = () => {
       </StIconsWrapper>
 
       {isLoginOpen && (
-        <StModal ref={modalRef}>
+        <StModal ref={loginModalRef}>
           <StAccountName>계정</StAccountName>
           <StButton onClick={() => navigate('/login')}>로그인</StButton>
           <StButton onClick={() => navigate('/mypage')}>프로필</StButton>

--- a/src/components/layout/MainLayout.jsx
+++ b/src/components/layout/MainLayout.jsx
@@ -1,0 +1,32 @@
+import Header from './Header';
+import Sidebar from './SideBar';
+import styled from 'styled-components';
+
+const MainLayout = ({ children }) => {
+  return (
+    <StContainer>
+      <Header />
+      <StMainContent>
+        <Sidebar />
+        <StContentWrapper>{children}</StContentWrapper>
+      </StMainContent>
+    </StContainer>
+  );
+};
+
+export default MainLayout;
+
+/** styled component */
+const StContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const StMainContent = styled.main`
+  display: flex;
+  flex: 1;
+`;
+
+const StContentWrapper = styled.div`
+  padding: 10px;
+`;

--- a/src/components/layout/MainLayout.jsx
+++ b/src/components/layout/MainLayout.jsx
@@ -1,4 +1,5 @@
 import { HeaderProvider } from '../../context/components/header/HeaderProvider';
+import { SidebarProvider } from '../../context/components/sidebar/SidebarProvider';
 import Header from './Header';
 import Sidebar from './SideBar';
 import styled from 'styled-components';
@@ -10,7 +11,9 @@ const MainLayout = ({ children }) => {
         <Header />
       </HeaderProvider>
       <StMainContent>
-        <Sidebar />
+        <SidebarProvider>
+          <Sidebar />
+        </SidebarProvider>
         <StContentWrapper>{children}</StContentWrapper>
       </StMainContent>
     </StContainer>

--- a/src/components/layout/MainLayout.jsx
+++ b/src/components/layout/MainLayout.jsx
@@ -1,3 +1,4 @@
+import { HeaderProvider } from '../../context/components/header/HeaderProvider';
 import Header from './Header';
 import Sidebar from './SideBar';
 import styled from 'styled-components';
@@ -5,7 +6,9 @@ import styled from 'styled-components';
 const MainLayout = ({ children }) => {
   return (
     <StContainer>
-      <Header />
+      <HeaderProvider>
+        <Header />
+      </HeaderProvider>
       <StMainContent>
         <Sidebar />
         <StContentWrapper>{children}</StContentWrapper>

--- a/src/components/layout/SideBar.jsx
+++ b/src/components/layout/SideBar.jsx
@@ -2,39 +2,43 @@ import styled from 'styled-components';
 import { FiHome, FiSearch, FiHeart } from 'react-icons/fi';
 import { FaRegBookmark } from 'react-icons/fa';
 import { fontSize } from '../../styles/fontSize';
-import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useSidebar } from '../../context/components/sidebar/useSidebar';
 
 const SideBar = () => {
-  const [isExpand, setIsExpand] = useState(false);
+  const { isSidebarExpand, setIsSidebarExpand } = useSidebar();
   const navigate = useNavigate();
 
   return (
-    <StContainer $isExpand={isExpand} onMouseEnter={() => setIsExpand(true)} onMouseLeave={() => setIsExpand(false)}>
+    <StContainer
+      $isExpand={isSidebarExpand}
+      onMouseEnter={() => setIsSidebarExpand(true)}
+      onMouseLeave={() => setIsSidebarExpand(false)}
+    >
       <StMenu>
         <StMenuItem onClick={() => navigate('/')}>
           <StIconWrapper>
             <FiHome />
           </StIconWrapper>
-          <StText $isExpand={isExpand}>홈</StText>
+          <StText $isExpand={isSidebarExpand}>홈</StText>
         </StMenuItem>
         <StMenuItem onClick={() => navigate('/search')}>
           <StIconWrapper>
             <FiSearch />
           </StIconWrapper>
-          <StText $isExpand={isExpand}>검색</StText>
+          <StText $isExpand={isSidebarExpand}>검색</StText>
         </StMenuItem>
         <StMenuItem>
           <StIconWrapper>
             <FiHeart />
           </StIconWrapper>
-          <StText $isExpand={isExpand}>좋아요</StText>
+          <StText $isExpand={isSidebarExpand}>좋아요</StText>
         </StMenuItem>
         <StMenuItem>
           <StIconWrapper>
             <FaRegBookmark />
           </StIconWrapper>
-          <StText $isExpand={isExpand}>북마크</StText>
+          <StText $isExpand={isSidebarExpand}>북마크</StText>
         </StMenuItem>
       </StMenu>
     </StContainer>

--- a/src/context/auth/AuthContext.js
+++ b/src/context/auth/AuthContext.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export const AuthContext = createContext();

--- a/src/context/auth/AuthProvider.jsx
+++ b/src/context/auth/AuthProvider.jsx
@@ -1,7 +1,6 @@
-import { createContext, useEffect, useState } from 'react';
-import { supabase } from '../services/supabaseClient';
-
-export const AuthContext = createContext(null);
+import { useEffect, useState } from 'react';
+import { supabase } from '../../services/supabaseClient';
+import { AuthContext } from './AuthContext';
 
 export const AuthProvider = ({ children }) => {
   const [isLogin, setIsLogin] = useState(false);

--- a/src/context/auth/useAuth.js
+++ b/src/context/auth/useAuth.js
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { AuthContext } from '../context/AuthProvider';
+import { AuthContext } from './AuthContext';
 
 export const useAuth = () => {
   return useContext(AuthContext);

--- a/src/context/components/header/HeaderContext.js
+++ b/src/context/components/header/HeaderContext.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export const HeaderContext = createContext();

--- a/src/context/components/header/HeaderProvider.jsx
+++ b/src/context/components/header/HeaderProvider.jsx
@@ -1,0 +1,31 @@
+import { useState, useRef, useEffect } from 'react';
+import { HeaderContext } from './HeaderContext';
+
+export const HeaderProvider = ({ children }) => {
+  const [isLoginOpen, setIsLoginOpen] = useState(false);
+  const loginModalRef = useRef(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (loginModalRef.current && !loginModalRef.current.contains(event.target)) {
+        setIsLoginOpen(false);
+      }
+    };
+
+    // 모달이 열린 상태에서만 외부 클릭 감지 활성화
+    if (isLoginOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    } else {
+      document.removeEventListener('mousedown', handleClickOutside);
+    }
+
+    // 언마운트되면 이벤트 리스너 제거
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isLoginOpen]);
+
+  const value = { isLoginOpen, setIsLoginOpen, loginModalRef };
+
+  return <HeaderContext.Provider value={value}>{children}</HeaderContext.Provider>;
+};

--- a/src/context/components/header/HeaderProvider.jsx
+++ b/src/context/components/header/HeaderProvider.jsx
@@ -1,9 +1,14 @@
 import { useState, useRef, useEffect } from 'react';
 import { HeaderContext } from './HeaderContext';
+import { useAuth } from '../../auth/useAuth';
+import { supabase } from '../../../services/supabaseClient';
+import { useNavigate } from 'react-router-dom';
 
 export const HeaderProvider = ({ children }) => {
   const [isLoginOpen, setIsLoginOpen] = useState(false);
   const loginModalRef = useRef(null);
+  const { isLogin } = useAuth();
+  const navigate = useNavigate();
 
   useEffect(() => {
     const handleClickOutside = (event) => {
@@ -25,7 +30,16 @@ export const HeaderProvider = ({ children }) => {
     };
   }, [isLoginOpen]);
 
-  const value = { isLoginOpen, setIsLoginOpen, loginModalRef };
+  const handleAuthAction = async () => {
+    if (isLogin) {
+      await supabase.auth.signOut();
+      navigate('/');
+    } else {
+      navigate('/login');
+    }
+  };
+
+  const value = { isLoginOpen, setIsLoginOpen, loginModalRef, handleAuthAction };
 
   return <HeaderContext.Provider value={value}>{children}</HeaderContext.Provider>;
 };

--- a/src/context/components/header/useHeader.js
+++ b/src/context/components/header/useHeader.js
@@ -1,0 +1,6 @@
+import { useContext } from 'react';
+import { HeaderContext } from './HeaderContext';
+
+export const useHeader = () => {
+  return useContext(HeaderContext);
+};

--- a/src/context/components/sidebar/SidebarContext.js
+++ b/src/context/components/sidebar/SidebarContext.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export const SidebarContext = createContext();

--- a/src/context/components/sidebar/SidebarProvider.jsx
+++ b/src/context/components/sidebar/SidebarProvider.jsx
@@ -1,0 +1,10 @@
+import { useState } from 'react';
+import { SidebarContext } from './SidebarContext';
+
+export const SidebarProvider = ({ children }) => {
+  const [isSidebarExpand, setIsSidebarExpand] = useState(false);
+
+  const value = { isSidebarExpand, setIsSidebarExpand };
+
+  return <SidebarContext.Provider value={value}>{children}</SidebarContext.Provider>;
+};

--- a/src/context/components/sidebar/useSidebar.js
+++ b/src/context/components/sidebar/useSidebar.js
@@ -1,0 +1,6 @@
+import { useContext } from 'react';
+import { SidebarContext } from './SidebarContext';
+
+export const useSidebar = () => {
+  return useContext(SidebarContext);
+};

--- a/src/context/post/PostContext.js
+++ b/src/context/post/PostContext.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export const PostContext = createContext();

--- a/src/context/post/PostProvider.jsx
+++ b/src/context/post/PostProvider.jsx
@@ -1,0 +1,10 @@
+import { useState } from 'react';
+import { PostContext } from './PostContext';
+
+export const PostProvider = ({ children }) => {
+  const [posts] = useState([]); // 전체 게시물 리스트
+
+  const value = { posts };
+
+  return <PostContext.Provider value={value}>{children}</PostContext.Provider>;
+};

--- a/src/context/post/usePost.js
+++ b/src/context/post/usePost.js
@@ -1,0 +1,6 @@
+import { useContext } from 'react';
+import { PostContext } from './PostProvider';
+
+export const usePost = () => {
+  return useContext(PostContext);
+};

--- a/src/context/user/UserContext.js
+++ b/src/context/user/UserContext.js
@@ -1,0 +1,6 @@
+import { useContext } from 'react';
+import { UserContext } from './UserProvider';
+
+export const useUser = () => {
+  return useContext(UserContext);
+};

--- a/src/context/user/UserProvider.jsx
+++ b/src/context/user/UserProvider.jsx
@@ -1,0 +1,12 @@
+import { useState } from 'react';
+import { UserContext } from './UserContext';
+
+export const UserProvider = ({ children }) => {
+  const [userData] = useState({}); // 전체 게시물 리스트
+  const [followers] = useState([]); // 사용자가 팔로우한 사람 목록
+  const [following] = useState([]); // 사용자를 팔로우한 사람 목록
+
+  const value = { userData, followers, following };
+
+  return <UserContext.Provider value={value}>{children}</UserContext.Provider>;
+};

--- a/src/context/user/useUser.js
+++ b/src/context/user/useUser.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export const UserContext = createContext();

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,8 +1,8 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.jsx';
-import { AuthProvider } from './context/AuthProvider.jsx';
-import { GlobalStyle } from './styles/GlobalStyle.jsx';
+import { AuthProvider } from './context/auth/AuthProvider';
+import { GlobalStyle } from './styles/GlobalStyle';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,34 +1,11 @@
-import Header from '../components/layout/Header';
-import Sidebar from '../components/layout/SideBar';
-import styled from 'styled-components';
+import MainLayout from '../components/layout/MainLayout';
 
 const Home = () => {
   return (
-    <StContainer>
-      <Header />
-      <StMainContent>
-        <Sidebar />
-        <StContentWrapper>
-          <div>Home</div>
-        </StContentWrapper>
-      </StMainContent>
-    </StContainer>
+    <MainLayout>
+      <div>Home</div>
+    </MainLayout>
   );
 };
 
 export default Home;
-
-/** styled component */
-const StContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-`;
-
-const StMainContent = styled.main`
-  display: flex;
-  flex: 1;
-`;
-
-const StContentWrapper = styled.div`
-  padding: 10px;
-`;


### PR DESCRIPTION
### 관련 이슈
context api 방식 초기 구현 및 로그인/로그아웃 가능하도록 수정

### 작업 요약
✅ context 폴더 내부에 auth, post, user, components 폴더를 두었습니다.
Context, Provider, 커스텀 훅 이 세개의 파일을 항상 세트로 갖게 하였습니다.
- 전역 상태 관리: auth, post, user 폴더
    |- auth 폴더에는 인증 관련 정보(현재 로그인 여부를 나타내는 isLogin 상태 존재)를 넣어주세요.
    |- post 폴더에는 인증게시물 관련 정보(현재 전체 게시물 리스트를 갖는 posts 상태 존재)를 넣어주세요.
    |- user 폴더에는 사용자 관련 정보(현재 로그인 되어 있는 사용자 정보를 갖는 userData 상태 존재)를 넣어주세요.
    !! userData에 주석이 잘못 달려있는 것을 확인하였습니다.
- **특정 페이지(컴포넌트)에서만 사용되는** 부분 전역 상태 관리: components 폴더
    |- 예시로 Header와 Sidebar에서만 사용되는 훅과 함수들을 components 폴더 하위에 컴포넌트 이름으로 폴더를 추가하여, 동작 테스트를 완료하였습니다.

✅ 계정 프로필 클릭하면 나오는 첫번째 버튼이 로그인 상태면 로그아웃 버튼으로 동작하게,
로그아웃 상태면 로그인 버튼으로 동작하게 수정하였습니다.

### 리뷰 요구 사항
- 나중에 풀땡기셔서 기존 기능들이 제대로 동작하는지 체크 한번더 부탁드립니다.
- context 방식으로 변경한 형식 확인 부탁드립니다.

### 미리보기
- 로그인, 로그아웃 기능

https://github.com/user-attachments/assets/8ef58da7-eac4-439b-87d3-07dd5703051a



