### PR TITLE
Feat: 모달창 기본 레이아웃과 관련 기능 구현

### DIFF
--- a/src/components/modals/PostCreateModal.jsx
+++ b/src/components/modals/PostCreateModal.jsx
@@ -4,28 +4,32 @@ import { fontSize } from '../../styles/fontSize';
 import { useRef, useState } from 'react';
 
 const PostCreateModal = ({ isOpen, close }) => {
-  // useState와 useRef가 if문 위에 있어야 경고(?) 코드가 안 뜨지만, 이러면 모달창은 닫았다 열어도 이미지가 그대로 남아있음 (정보는 x)(submit버튼을 눌렀을 땐 이미지도 초기화됨)
-  const [imgPreview, setImagePreview] = useState(''); // img 파일이 imgPreview 상태에 Base64 문자열로 들어갈 것이기 때문에 기본값이 ""임
-  const imgRef = useRef(null); //useRef는 컴포넌트 안에서 DOM 요소나 값을 직접 참조!! ==> useState()를 사용할 때와 달리 input태그의 값에 직접 접근할 수 있어 불필요한 리렌더링을 줄일 수 있음
+  const [imgPreview, setImagePreview] = useState('');   // img 파일이 imgPreview 상태에 Base64 문자열로 들어갈 것이기 때문에 기본값이 ""임
+  const imgRef = useRef(null);                          // useRef는 컴포넌트 안에서 DOM 요소나 값을 직접 참조!! ==> useState()를 사용할 때와 달리 input태그의 값에 직접 접근할 수 있어 불필요한 리렌더링을 줄일 수 있음
 
   if (!isOpen) {
-    return null; // isOpen이 false면 렌더링하지 않음
+    return null; // isOpen이 false면 모달창을 렌더링하지 않음
+  }
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    alert("폼이 제출되었습니다!") //
   }
 
   const handleImgPreview = () => {
-    const file = imgRef.current.files[0]; // imgRef.current는 input요소를 참조 => files는 그 input에서 선택한 파일들 => files[0]는 선택된 첫 번째 파일(preview용)
-    const reader = new FileReader(); // FileReader 객체 생성 => new FileReader는 컴퓨터에게  "input에 들어가는 파일을 읽어서 JavaScript에서 사용할 수 있는 형태로 변환해줘!"라고 말하는 객체
-    reader.readAsDataURL(file); // .readAsDataURL은 이제 읽는 방식을 "JavaScript에서 사용할 수 있는 형태인 Base64 형식으로 변환해줘!"라고 말하는 거
+    const file = imgRef.current.files[0];               // 1) imgRef.current는 input요소를 참조 => files는 그 input에서 선택한 파일들 => files[0]는 선택된 첫 번째 파일(preview용)
+    const reader = new FileReader();                    // 2) FileReader 객체 생성 => new FileReader는 컴퓨터에게  "input에 들어가는 파일을 읽어서 JavaScript에서 사용할 수 있는 형태로 변환해줘!"라고 말하는 객체
+    reader.readAsDataURL(file);                         // 3) .readAsDataURL은 이제 읽는 방식을 "JavaScript에서 사용할 수 있는 형태인 Base64 형식으로 변환해줘!"라고 말하는 거
     reader.onloadend = () => {
       // 파일 읽기가 끝나면 실행
-      setImagePreview(reader.result); // 변환된 데이터 URL을 imgFile 상태에 저장 => 상태관리를 하는 것!
+      setImagePreview(reader.result);                   // 4) 변환된 데이터 URL을 imgFile 상태에 저장 => 상태관리를 하는 것!
     };
   };
 
   return (
     <StOverlay>
       <StContainer>
-          <StForm> 
+          <StForm onSubmit={handleSubmit}> 
             <h2>모달창</h2>
             <StCloseButton onClick={close}>닫기</StCloseButton>
             <StInputWrapper>
@@ -58,8 +62,9 @@ const PostCreateModal = ({ isOpen, close }) => {
 
 export default PostCreateModal;
 
-// ----------------------------------- styled-components 너무 많아 ㅠㅠㅠㅠㅠㅠ
+// ----------------------------------- styled-components
 
+// 겹치는 디자인이 많은 관계로 디자인용 2 변수를 생성
 const flexCenter = `
   display: flex;
   justify-content: center;
@@ -83,7 +88,7 @@ const StOverlay = styled.div`
   left: 0;
   width: 100vw;
   height: 100vh;
-  background-color: rgba(0, 0, 0, 0.5); /* 배경 어둡게 처리 */
+  background-color: rgba(0, 0, 0, 0.5); // 배경 어둡게 처리 
   ${flexCenter}
 `;
 
@@ -103,12 +108,17 @@ const StForm = styled.form`
   height: 100%;
   ${flexCenter};
   flex-direction: column;
+
+  h2 {
+    margin-top: 50px;
+    color: ${color.main};
+  }
 `;
 
 const StSubmitButton = styled.button`
   ${BtnStyle}
   position: absolute;
-  bottom: 20px; /* 모달 내부에서 하단에 위치하도록 설정 */
+  bottom: 20px; // 모달 내부에서 하단에 위치하도록 설정 
   right: 50%;
   transform: translateX(50%);
 `;
@@ -120,17 +130,18 @@ const StInputWrapper = styled.div`
 
 const Stdiv = styled.div`
   width: 40%;
-  margin: 5%;
+  margin: 0 5% 5% 5%;
   height: 500px;
   ${flexCenter}
-  border: ${({ imgPreview }) => (imgPreview ? 'none' : `5px dotted ${color.gray}`)};
+  border: ${({ imgPreview }) => (imgPreview ? 'none' : `5px dotted ${color.gray}`)}; // input에 이미지 파일이 들어오지 않았을 때만 테투리 구현
   border-radius: 10px;
   box-sizing: border-box;
+
 
   img {
     width: 100%;
     height: 100%;
-    object-fit: cover; // 이미지 비율 유지하면서 부모요소의 크기에 맞춤
+    border-radius: 10px; // 이미지 비율 유지하면서 부모요소의 크기에 맞춤
     display: ${({ imgPreview }) => (!imgPreview ? 'none' : 'block')};
   }
 

--- a/src/components/modals/PostCreateModal.jsx
+++ b/src/components/modals/PostCreateModal.jsx
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 import { color } from '../../styles/color';
 import { fontSize } from '../../styles/fontSize';
 import { useRef, useState } from 'react';
-import { BiFontColor } from 'react-icons/bi';
 
 const PostCreateModal = ({ isOpen, close }) => {
   // useState와 useRef가 if문 위에 있어야 경고(?) 코드가 안 뜨지만, 이러면 모달창은 닫았다 열어도 이미지가 그대로 남아있음 (정보는 x)(submit버튼을 눌렀을 땐 이미지도 초기화됨)
@@ -74,7 +73,7 @@ const BtnStyle = `
   border-radius: 5px;
   cursor: pointer;
   font-size: ${fontSize.medium};
-  font-weight: 700;Z
+  font-weight: 700;
   color: ${color.white};
 `;
 
@@ -138,8 +137,9 @@ const Stdiv = styled.div`
   label {
     color: ${color.main};
     cursor: pointer;
-    display: ${({ imgPreview }) =>
-      imgPreview ? 'none' : 'block'}; // imgPreview 값이 "true"이면 label display를 "none"으로 바꾸기
+    font-size: ${fontSize.medium};
+    font-weight: 800;
+    display: ${({ imgPreview }) => imgPreview ? 'none' : 'block'}; // imgPreview 값이 "true"이면 label display를 "none"으로 바꾸기
   }
 
   input {
@@ -174,6 +174,7 @@ const StLabel = styled.label`
   textarea {
     min-width: 30vw;
     min-height: 15vh;
+    border-radius: 10px;
   }
 `;
 
@@ -183,4 +184,3 @@ const StCloseButton = styled.button`
   right: 10px;
   top: 10px;
 `;
-

--- a/src/components/modals/PostCreateModal.jsx
+++ b/src/components/modals/PostCreateModal.jsx
@@ -7,16 +7,17 @@ const PostCreateModal = ({ isOpen, close }) => {
   if (!isOpen) {
     return null; // isOpen이 false면 렌더링하지 않음
   }
-  
-  const [imgPreview, setImagePreview] = useState(""); // img 파일이 imgPreview 상태에 Base64 문자열로 들어갈 것이기 때문에 기본값이 ""임
+
+  const [imgPreview, setImagePreview] = useState(''); // img 파일이 imgPreview 상태에 Base64 문자열로 들어갈 것이기 때문에 기본값이 ""임
   const imgRef = useRef(); //useRef는 컴포넌트 안에서 DOM 요소나 값을 직접 참조!! ==> useState()를 사용할 때와 달리 input태그의 값에 직접 접근할 수 있어 불필요한 리렌더링을 줄일 수 있음
 
   const handleImgPreview = () => {
-    const file = imgRef.current.files[0]  // imgRef.current는 input요소를 참조 => files는 그 input에서 선택한 파일들 => files[0]는 선택된 첫 번째 파일(preview용)
-    const reader = new FileReader();  // FileReader 객체 생성 => new FileReader는 컴퓨터에게  "input에 들어가는 파일을 읽어서 JavaScript에서 사용할 수 있는 형태로 변환해줘!"라고 말하는 객체
-    reader.readAsDataURL(file);   // .readAsDataURL은 이제 읽는 방식을 "JavaScript에서 사용할 수 있는 형태인 Base64 형식으로 변환해줘!"라고 말하는 거
-    reader.onloadend = () => {    // 파일 읽기가 끝나면 실행
-      setImagePreview(reader.result);  // 변환된 데이터 URL을 imgFile 상태에 저장 => 상태관리를 하는 것!
+    const file = imgRef.current.files[0]; // imgRef.current는 input요소를 참조 => files는 그 input에서 선택한 파일들 => files[0]는 선택된 첫 번째 파일(preview용)
+    const reader = new FileReader(); // FileReader 객체 생성 => new FileReader는 컴퓨터에게  "input에 들어가는 파일을 읽어서 JavaScript에서 사용할 수 있는 형태로 변환해줘!"라고 말하는 객체
+    reader.readAsDataURL(file); // .readAsDataURL은 이제 읽는 방식을 "JavaScript에서 사용할 수 있는 형태인 Base64 형식으로 변환해줘!"라고 말하는 거
+    reader.onloadend = () => {
+      // 파일 읽기가 끝나면 실행
+      setImagePreview(reader.result); // 변환된 데이터 URL을 imgFile 상태에 저장 => 상태관리를 하는 것!
     };
   };
 
@@ -28,10 +29,10 @@ const PostCreateModal = ({ isOpen, close }) => {
             <h2>모달창</h2>
             <StCloseButton onClick={close}>닫기</StCloseButton>
             <StInputWrapper>
-              <Stdiv>
-                <img src={imgPreview ? imgPreview : null} />
+              <Stdiv imgPreview={imgPreview}>
                 <label htmlFor="postImage">이미지 추가</label>
-                <input type="file" accept='image/*, video/*' id='postImage' onChange={handleImgPreview} ref={imgRef}/>
+                <img src={imgPreview ? imgPreview : null} />
+                <input type="file" accept="image/*, video/*" id="postImage" onChange={handleImgPreview} ref={imgRef} />
               </Stdiv>
               <StTextInputWrapper>
                 <StLabel>
@@ -52,7 +53,6 @@ const PostCreateModal = ({ isOpen, close }) => {
           </StForm>
         </StWrapper>
       </StContainer>
-
     </StOverlay>
   );
 };
@@ -106,6 +106,7 @@ const StForm = styled.form`
     border: none;
     border-radius: 5px;
     cursor: pointer;
+    font-size: ${fontSize.large};
   }
 `;
 
@@ -117,25 +118,26 @@ const StInputWrapper = styled.div`
 const Stdiv = styled.div`
   width: 40%;
   margin: 5%;
-  min-height: 500px;
+  min-height: 500px; // height으로 하면 이미지가 추가되기 전까지 Stdiv내부에 하얀 박스가 생김
+  max-height: 500px; // ???? 위에 달린 주석을 이유로 이 코드를 살렸는데.... 진짜 긴 사진 넣으니까 max-height를 넘어버림!!!!!
   ${flexCenter};
-  border: 5px dotted ${color.gray};
+  border: ${({ imgPreview }) => (imgPreview ? 'none' : `5px dotted ${color.gray}`)};
   border-radius: 10px;
-  position: relative; /* 추가된 부분 */
+  box-sizing: border-box;
 
   img {
     width: 100%;
     height: 100%;
-    object-fit: cover;
+    object-fit: cover; // 이미지 비율 유지하면서 부모요소의 크기에 맞춤
+    display: ${({ imgPreview }) => (!imgPreview ? 'none' : 'block')};
   }
 
   label {
     color: ${color.main};
-    font-size: ${fontSize.large};
-    font-weight: 700;
     cursor: pointer;
-    display: ${({imgPreview}) => imgPreview? 'none' : 'block'} // imgPreview 값이 "true"이면 label display를 "none"으로 바꾸기
-  };
+    display: ${({ imgPreview }) =>
+      imgPreview ? 'none' : 'block'}; // imgPreview 값이 "true"이면 label display를 "none"으로 바꾸기
+  }
 
   input {
     display: none;
@@ -146,8 +148,8 @@ const StTextInputWrapper = styled.div`
   width: 50%;
   height: 90%;
   flex-direction: column;
-  display: flex;
   justify-content: space-around;
+  display: flex;
   align-items: center;
   font-size: large;
 `;
@@ -176,5 +178,3 @@ const StCloseButton = styled.button`
   right: 10px;
   top: 10px;
 `;
-
-// 보통은 branch 기능별로 만들어서 커밋푸시 하긴 한다.

--- a/src/components/modals/PostCreateModal.jsx
+++ b/src/components/modals/PostCreateModal.jsx
@@ -26,32 +26,32 @@ const PostCreateModal = ({ isOpen, close }) => {
   return (
     <StOverlay>
       <StContainer>
-        <StForm> 
-          <h2>모달창</h2>
-          <StCloseButton onClick={close}>닫기</StCloseButton>
-          <StInputWrapper>
-            <Stdiv imgPreview={imgPreview}>
-              <label htmlFor="postImage">이미지 추가</label>
-              <img src={imgPreview ? imgPreview : null} />
-              <input type="file" accept="image/*, video/*" id="postImage" onChange={handleImgPreview} ref={imgRef} />
-            </Stdiv>
-            <StTextInputWrapper>
-              <StLabel>
-                제목
-                <input type="textarea" />
-              </StLabel>
-              <StLabel>
-                내용
-                <textarea name="" id=""></textarea>
-              </StLabel>
-              <StLabel>
-                태그
-                <input type="text" />
-              </StLabel>
-            </StTextInputWrapper>
-          </StInputWrapper>
-          <StSubmitButton type="submit">올리기</StSubmitButton>
-        </StForm>
+          <StForm> 
+            <h2>모달창</h2>
+            <StCloseButton onClick={close}>닫기</StCloseButton>
+            <StInputWrapper>
+              <Stdiv imgPreview={imgPreview}>
+                <label htmlFor="postImage">이미지 추가</label>
+                <img src={imgPreview ? imgPreview : null} />
+                <input type="file" accept="image/*, video/*" id="postImage" onChange={handleImgPreview} ref={imgRef} required/>
+              </Stdiv>
+              <StTextInputWrapper>
+                <StLabel>
+                  제목
+                  <input type="textarea" required/>
+                </StLabel>
+                <StLabel>
+                  내용
+                  <textarea required></textarea>
+                </StLabel>
+                <StLabel>
+                  태그
+                  <input type="text" required/>
+                </StLabel>
+              </StTextInputWrapper>
+            </StInputWrapper>
+            <StSubmitButton type="submit">올리기</StSubmitButton>
+          </StForm>
       </StContainer>
     </StOverlay>
   );
@@ -121,8 +121,7 @@ const StInputWrapper = styled.div`
 const Stdiv = styled.div`
   width: 40%;
   margin: 5%;
-  min-height: 500px; // height으로 하면 이미지가 추가되기 전까지 Stdiv내부에 하얀 박스가 생김
-  max-height: 500px; // ???? 위에 달린 주석을 이유로 이 코드를 살렸는데.... 진짜 긴 사진 넣으니까 max-height를 넘어버림!!!!!
+  height: 500px;
   ${flexCenter}
   border: ${({ imgPreview }) => (imgPreview ? 'none' : `5px dotted ${color.gray}`)};
   border-radius: 10px;
@@ -151,10 +150,11 @@ const StTextInputWrapper = styled.div`
   width: 50%;
   height: 90%;
   flex-direction: column;
-  justify-content: space-around;
+  justify-content: flex-start;
   display: flex;
   align-items: center;
   font-size: large;
+  gap: 70px;
 `;
 
 const StLabel = styled.label`
@@ -183,77 +183,3 @@ const StCloseButton = styled.button`
   top: 10px;
 `;
 
-//-----------------------------------------------------------------------------------------------supabase 연습
-
-////----------------------------------------------------------------연습 1 : 외부데이터 내부로 가져오기 & form
-
-// import { createClient } from '@supabase/supabase-js';
-// import React, {useEffect} from 'react';
-// import { supabase } from '../../services/supabaseClient';
-
-// // "태그"를 DB에서 가져오는 함수
-// const TemporaryFuncName = () => {
-//   const [tags, setTags] = useState([]);
-//   const [tag, setTag] = useState("");
-
-//   useEffect(() => {
-//     // 1. 데이터를 가져오는 함수 (***실패할 수도 있는 요청이니 try catch로 감싸기***)
-//     const getTags = async () => {
-//       try {
-//         const {data, error} = await supabase.from("tags").select("*") //외부(supabase)에서 데이터를 가져옴 (tags테이블에 있는 데이터 모두)
-//         if (error) throw error;
-//         setTags(data); // 가져온 데이터를 setTags에 넣으므로서 외부데이터를 내부에서 관리 가능한 상태로 만듬
-//         } catch (error) {
-//         console.log(error);
-//       }
-//     };
-//       // 2. 실행
-//       getTags();
-//   }, []);
-
-//   // 이 함수를 실행할 떄 status: 401(unauthorized)이 나오면 RLS
-//   const handleAddTag = async (e) => {
-//     e.preventDefault();
-//     await supabase.from("tags").insert({tag});
-//    //여기에 동기화 로직!!!!!!을 만들어서 supabase DB에도 들어가는 동.시.에. 화면에도 렌더링 되게 만들어야 함
-//     console.log("tags => ", tags);
-//     setTags((prev) => [
-//       ...prev,
-//       {
-//         todo: todo,
-//         created_at: data[0],
-//         writer_id: data[0], // session으로 얻어오는 법?????? 뭐지?????
-//         id: data[0].id, // id는 supabase가 자동으로 만들어주는 것!
-//       },
-//     ]);
-//    };
-
-//   // 가져온 외부데이터 내부데이터로 바꿨으니 이제 렌더링 하기
-//   return (
-//     // form 에 들어갈 "내용" 칸
-//         <input
-//           type="text"
-//           placeholder='태그를 입력하세요'
-//           value={tag}
-//           onChange={(e) => setTag(e.target.value)}
-//         />
-//         <button onClick={handleAddTag}>추가</button>
-
-//         <input list="tagList" id="tagsList">
-//         <datalist id="tagsList">
-//           {tags.map((tag) => {
-//             
-//            })
-// <option value="">
-//       
-//       {tags.map((tag, index) => (   // 아래 <div>태그 사이 렌더링은 숫자 리스트처럼 렌더링된다. (예시: 1. 왈왈왈)
-//         <div key={tag.id}>
-//           {index + 1}. {tag.tag}
-//         </div> // 특강 영상에서 id와 tag는 실제 데이터 테이블(?)에 있는 열으로 콘솔에서 확인 가능했다.
-//         ))}
-//     </div>
-//   );
-
-// };
-
-// export default TemporaryFuncName;

--- a/src/components/modals/PostCreateModal.jsx
+++ b/src/components/modals/PostCreateModal.jsx
@@ -4,8 +4,8 @@ import { fontSize } from '../../styles/fontSize';
 import { useRef, useState } from 'react';
 
 const PostCreateModal = ({ isOpen, close }) => {
-  const [imgPreview, setImagePreview] = useState('');   // img 파일이 imgPreview 상태에 Base64 문자열로 들어갈 것이기 때문에 기본값이 ""임
-  const imgRef = useRef(null);                          // useRef는 컴포넌트 안에서 DOM 요소나 값을 직접 참조!! ==> useState()를 사용할 때와 달리 input태그의 값에 직접 접근할 수 있어 불필요한 리렌더링을 줄일 수 있음
+  const [imgPreview, setImagePreview] = useState(''); // img 파일이 imgPreview 상태에 Base64 문자열로 들어갈 것이기 때문에 기본값이 ""임
+  const imgRef = useRef(null); // useRef는 컴포넌트 안에서 DOM 요소나 값을 직접 참조!! ==> useState()를 사용할 때와 달리 input태그의 값에 직접 접근할 수 있어 불필요한 리렌더링을 줄일 수 있음
 
   if (!isOpen) {
     return null; // isOpen이 false면 모달창을 렌더링하지 않음
@@ -13,48 +13,57 @@ const PostCreateModal = ({ isOpen, close }) => {
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    alert("폼이 제출되었습니다!") //
-  }
+    alert('폼이 제출되었습니다!'); //
+  };
 
   const handleImgPreview = () => {
-    const file = imgRef.current.files[0];               // 1) imgRef.current는 input요소를 참조 => files는 그 input에서 선택한 파일들 => files[0]는 선택된 첫 번째 파일(preview용)
-    const reader = new FileReader();                    // 2) FileReader 객체 생성 => new FileReader는 컴퓨터에게  "input에 들어가는 파일을 읽어서 JavaScript에서 사용할 수 있는 형태로 변환해줘!"라고 말하는 객체
-    reader.readAsDataURL(file);                         // 3) .readAsDataURL은 이제 읽는 방식을 "JavaScript에서 사용할 수 있는 형태인 Base64 형식으로 변환해줘!"라고 말하는 거
+    const imgFile = imgRef.current.imgFiles[0]; // 1) imgRef.current는 input요소를 참조 => files는 그 input에서 선택한 파일들 => files[0]는 선택된 첫 번째 파일(preview용)
+    const reader = new FileReader(); // 2) FileReader 객체 생성 => new FileReader는 컴퓨터에게  "input에 들어가는 파일을 읽어서 JavaScript에서 사용할 수 있는 형태로 변환해줘!"라고 말하는 객체
+    reader.readAsDataURL(imgFile); // 3) .readAsDataURL은 이제 읽는 방식을 "JavaScript에서 사용할 수 있는 형태인 Base64 형식으로 변환해줘!"라고 말하는 거
     reader.onloadend = () => {
       // 파일 읽기가 끝나면 실행
-      setImagePreview(reader.result);                   // 4) 변환된 데이터 URL을 imgFile 상태에 저장 => 상태관리를 하는 것!
+      setImagePreview(reader.result); // 4) 변환된 데이터 URL을 imgFile 상태에 저장 => 상태관리를 하는 것!
     };
   };
 
   return (
     <StOverlay>
       <StContainer>
-          <StForm onSubmit={handleSubmit}> 
-            <h2>모달창</h2>
-            <StCloseButton onClick={close}>닫기</StCloseButton>
-            <StInputWrapper>
-              <Stdiv imgPreview={imgPreview}>
-                <label htmlFor="postImage">이미지 추가</label>
-                <img src={imgPreview ? imgPreview : null} />
-                <input type="file" accept="image/*, video/*" id="postImage" onChange={handleImgPreview} ref={imgRef} required/>
-              </Stdiv>
-              <StTextInputWrapper>
-                <StLabel>
-                  제목
-                  <input type="textarea" required/>
-                </StLabel>
-                <StLabel>
-                  내용
-                  <textarea required></textarea>
-                </StLabel>
-                <StLabel>
-                  태그
-                  <input type="text" required/>
-                </StLabel>
-              </StTextInputWrapper>
-            </StInputWrapper>
-            <StSubmitButton type="submit">올리기</StSubmitButton>
-          </StForm>
+        <StForm onSubmit={handleSubmit}>
+          <h2>모달창</h2>
+          <StCloseButton type="button" onClick={close}>
+            닫기
+          </StCloseButton>
+          <StInputWrapper>
+            <Stdiv imgPreview={imgPreview}>
+              <label htmlFor="postImage">이미지 추가</label>
+              <img src={imgPreview ? imgPreview : null} multiple alt='이미지 미리보기 실패'/>
+              <input
+                type="file"
+                accept="image/*, video/*"
+                id="postImage"
+                onChange={handleImgPreview}
+                ref={imgRef}
+                required
+              />
+            </Stdiv>
+            <StTextInputWrapper>
+              <StLabel>
+                제목
+                <input type="textarea" required />
+              </StLabel>
+              <StLabel>
+                내용
+                <textarea required></textarea>
+              </StLabel>
+              <StLabel>
+                태그
+                <input type="text" required />
+              </StLabel>
+            </StTextInputWrapper>
+          </StInputWrapper>
+          <StSubmitButton type="submit">올리기</StSubmitButton>
+        </StForm>
       </StContainer>
     </StOverlay>
   );
@@ -88,7 +97,7 @@ const StOverlay = styled.div`
   left: 0;
   width: 100vw;
   height: 100vh;
-  background-color: rgba(0, 0, 0, 0.5); // 배경 어둡게 처리 
+  background-color: rgba(0, 0, 0, 0.5); // 배경 어둡게 처리
   ${flexCenter}
 `;
 
@@ -118,7 +127,7 @@ const StForm = styled.form`
 const StSubmitButton = styled.button`
   ${BtnStyle}
   position: absolute;
-  bottom: 20px; // 모달 내부에서 하단에 위치하도록 설정 
+  bottom: 20px; // 모달 내부에서 하단에 위치하도록 설정
   right: 50%;
   transform: translateX(50%);
 `;
@@ -133,10 +142,10 @@ const Stdiv = styled.div`
   margin: 0 5% 5% 5%;
   height: 500px;
   ${flexCenter}
-  border: ${({ imgPreview }) => (imgPreview ? 'none' : `5px dotted ${color.gray}`)}; // input에 이미지 파일이 들어오지 않았을 때만 테투리 구현
+  border: ${({ imgPreview }) =>
+    imgPreview ? 'none' : `5px dotted ${color.gray}`}; // input에 이미지 파일이 들어오지 않았을 때만 테투리 구현
   border-radius: 10px;
   box-sizing: border-box;
-
 
   img {
     width: 100%;
@@ -150,7 +159,8 @@ const Stdiv = styled.div`
     cursor: pointer;
     font-size: ${fontSize.medium};
     font-weight: 800;
-    display: ${({ imgPreview }) => imgPreview ? 'none' : 'block'}; // imgPreview 값이 "true"이면 label display를 "none"으로 바꾸기
+    display: ${({ imgPreview }) =>
+      imgPreview ? 'none' : 'block'}; // imgPreview 값이 "true"이면 label display를 "none"으로 바꾸기
   }
 
   input {

--- a/src/components/modals/PostCreateModal.jsx
+++ b/src/components/modals/PostCreateModal.jsx
@@ -2,14 +2,16 @@ import styled from 'styled-components';
 import { color } from '../../styles/color';
 import { fontSize } from '../../styles/fontSize';
 import { useRef, useState } from 'react';
+import { BiFontColor } from 'react-icons/bi';
 
 const PostCreateModal = ({ isOpen, close }) => {
+  // useState와 useRef가 if문 위에 있어야 경고(?) 코드가 안 뜨지만, 이러면 모달창은 닫았다 열어도 이미지가 그대로 남아있음 (정보는 x)(submit버튼을 눌렀을 땐 이미지도 초기화됨)
+  const [imgPreview, setImagePreview] = useState(''); // img 파일이 imgPreview 상태에 Base64 문자열로 들어갈 것이기 때문에 기본값이 ""임
+  const imgRef = useRef(null); //useRef는 컴포넌트 안에서 DOM 요소나 값을 직접 참조!! ==> useState()를 사용할 때와 달리 input태그의 값에 직접 접근할 수 있어 불필요한 리렌더링을 줄일 수 있음
+
   if (!isOpen) {
     return null; // isOpen이 false면 렌더링하지 않음
   }
-
-  const [imgPreview, setImagePreview] = useState(''); // img 파일이 imgPreview 상태에 Base64 문자열로 들어갈 것이기 때문에 기본값이 ""임
-  const imgRef = useRef(); //useRef는 컴포넌트 안에서 DOM 요소나 값을 직접 참조!! ==> useState()를 사용할 때와 달리 input태그의 값에 직접 접근할 수 있어 불필요한 리렌더링을 줄일 수 있음
 
   const handleImgPreview = () => {
     const file = imgRef.current.files[0]; // imgRef.current는 input요소를 참조 => files는 그 input에서 선택한 파일들 => files[0]는 선택된 첫 번째 파일(preview용)
@@ -24,34 +26,32 @@ const PostCreateModal = ({ isOpen, close }) => {
   return (
     <StOverlay>
       <StContainer>
-        <StWrapper>
-          <StForm>
-            <h2>모달창</h2>
-            <StCloseButton onClick={close}>닫기</StCloseButton>
-            <StInputWrapper>
-              <Stdiv imgPreview={imgPreview}>
-                <label htmlFor="postImage">이미지 추가</label>
-                <img src={imgPreview ? imgPreview : null} />
-                <input type="file" accept="image/*, video/*" id="postImage" onChange={handleImgPreview} ref={imgRef} />
-              </Stdiv>
-              <StTextInputWrapper>
-                <StLabel>
-                  제목
-                  <input type="textarea" />
-                </StLabel>
-                <StLabel>
-                  내용
-                  <textarea name="" id=""></textarea>
-                </StLabel>
-                <StLabel>
-                  태그
-                  <input type="text" />
-                </StLabel>
-              </StTextInputWrapper>
-            </StInputWrapper>
-            <button type="submit">올리기</button>
-          </StForm>
-        </StWrapper>
+        <StForm> 
+          <h2>모달창</h2>
+          <StCloseButton onClick={close}>닫기</StCloseButton>
+          <StInputWrapper>
+            <Stdiv imgPreview={imgPreview}>
+              <label htmlFor="postImage">이미지 추가</label>
+              <img src={imgPreview ? imgPreview : null} />
+              <input type="file" accept="image/*, video/*" id="postImage" onChange={handleImgPreview} ref={imgRef} />
+            </Stdiv>
+            <StTextInputWrapper>
+              <StLabel>
+                제목
+                <input type="textarea" />
+              </StLabel>
+              <StLabel>
+                내용
+                <textarea name="" id=""></textarea>
+              </StLabel>
+              <StLabel>
+                태그
+                <input type="text" />
+              </StLabel>
+            </StTextInputWrapper>
+          </StInputWrapper>
+          <StSubmitButton type="submit">올리기</StSubmitButton>
+        </StForm>
       </StContainer>
     </StOverlay>
   );
@@ -67,6 +67,16 @@ const flexCenter = `
   align-items: center;
 `;
 
+const BtnStyle = `
+  padding: 10px 15px;
+  background-color: ${color.main};
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: ${fontSize.medium};
+  color: ${BiFontColor.white};
+`;
+
 const StOverlay = styled.div`
   position: fixed;
   top: 0;
@@ -78,20 +88,14 @@ const StOverlay = styled.div`
 `;
 
 const StContainer = styled.div`
-  max-width: 70vw; /* 모달창 최대 크기 설정 */
+  min-width: 70vw; // 모달창 최대 크기 설정
   height: 90%;
   flex-direction: column;
   ${flexCenter};
-  background-color: ${color.white}; /* 모달창 배경색 */
+  background-color: ${color.white}; // 모달창 배경색
   border-radius: 10px;
-  position: relative; /* 위치 설정 */
-`;
-
-const StWrapper = styled.div`
-  width: 70vw;
-  height: 800px;
-  ${flexCenter};
-  border-radius: 10px;
+  position: relative; // 위치 설정
+  box-sizing: border-box;
 `;
 
 const StForm = styled.form`
@@ -99,15 +103,14 @@ const StForm = styled.form`
   height: 100%;
   ${flexCenter};
   flex-direction: column;
+`;
 
-  button {
-    padding: 10px 15px;
-    background-color: ${color.main};
-    border: none;
-    border-radius: 5px;
-    cursor: pointer;
-    font-size: ${fontSize.large};
-  }
+const StSubmitButton = styled.button`
+  ${BtnStyle}
+  position: absolute;
+  bottom: 20px; /* 모달 내부에서 하단에 위치하도록 설정 */
+  right: 50%;
+  transform: translateX(50%);
 `;
 
 const StInputWrapper = styled.div`
@@ -120,7 +123,7 @@ const Stdiv = styled.div`
   margin: 5%;
   min-height: 500px; // height으로 하면 이미지가 추가되기 전까지 Stdiv내부에 하얀 박스가 생김
   max-height: 500px; // ???? 위에 달린 주석을 이유로 이 코드를 살렸는데.... 진짜 긴 사진 넣으니까 max-height를 넘어버림!!!!!
-  ${flexCenter};
+  ${flexCenter}
   border: ${({ imgPreview }) => (imgPreview ? 'none' : `5px dotted ${color.gray}`)};
   border-radius: 10px;
   box-sizing: border-box;
@@ -174,7 +177,83 @@ const StLabel = styled.label`
 `;
 
 const StCloseButton = styled.button`
+  ${BtnStyle}
   position: absolute;
   right: 10px;
   top: 10px;
 `;
+
+//-----------------------------------------------------------------------------------------------supabase 연습
+
+////----------------------------------------------------------------연습 1 : 외부데이터 내부로 가져오기 & form
+
+// import { createClient } from '@supabase/supabase-js';
+// import React, {useEffect} from 'react';
+// import { supabase } from '../../services/supabaseClient';
+
+// // "태그"를 DB에서 가져오는 함수
+// const TemporaryFuncName = () => {
+//   const [tags, setTags] = useState([]);
+//   const [tag, setTag] = useState("");
+
+//   useEffect(() => {
+//     // 1. 데이터를 가져오는 함수 (***실패할 수도 있는 요청이니 try catch로 감싸기***)
+//     const getTags = async () => {
+//       try {
+//         const {data, error} = await supabase.from("tags").select("*") //외부(supabase)에서 데이터를 가져옴 (tags테이블에 있는 데이터 모두)
+//         if (error) throw error;
+//         setTags(data); // 가져온 데이터를 setTags에 넣으므로서 외부데이터를 내부에서 관리 가능한 상태로 만듬
+//         } catch (error) {
+//         console.log(error);
+//       }
+//     };
+//       // 2. 실행
+//       getTags();
+//   }, []);
+
+//   // 이 함수를 실행할 떄 status: 401(unauthorized)이 나오면 RLS
+//   const handleAddTag = async (e) => {
+//     e.preventDefault();
+//     await supabase.from("tags").insert({tag});
+//    //여기에 동기화 로직!!!!!!을 만들어서 supabase DB에도 들어가는 동.시.에. 화면에도 렌더링 되게 만들어야 함
+//     console.log("tags => ", tags);
+//     setTags((prev) => [
+//       ...prev,
+//       {
+//         todo: todo,
+//         created_at: data[0],
+//         writer_id: data[0], // session으로 얻어오는 법?????? 뭐지?????
+//         id: data[0].id, // id는 supabase가 자동으로 만들어주는 것!
+//       },
+//     ]);
+//    };
+
+//   // 가져온 외부데이터 내부데이터로 바꿨으니 이제 렌더링 하기
+//   return (
+//     // form 에 들어갈 "내용" 칸
+//         <input
+//           type="text"
+//           placeholder='태그를 입력하세요'
+//           value={tag}
+//           onChange={(e) => setTag(e.target.value)}
+//         />
+//         <button onClick={handleAddTag}>추가</button>
+
+//         <input list="tagList" id="tagsList">
+//         <datalist id="tagsList">
+//           {tags.map((tag) => {
+//             
+//            })
+// <option value="">
+//       
+//       {tags.map((tag, index) => (   // 아래 <div>태그 사이 렌더링은 숫자 리스트처럼 렌더링된다. (예시: 1. 왈왈왈)
+//         <div key={tag.id}>
+//           {index + 1}. {tag.tag}
+//         </div> // 특강 영상에서 id와 tag는 실제 데이터 테이블(?)에 있는 열으로 콘솔에서 확인 가능했다.
+//         ))}
+//     </div>
+//   );
+
+// };
+
+// export default TemporaryFuncName;

--- a/src/components/modals/PostCreateModal.jsx
+++ b/src/components/modals/PostCreateModal.jsx
@@ -74,7 +74,8 @@ const BtnStyle = `
   border-radius: 5px;
   cursor: pointer;
   font-size: ${fontSize.medium};
-  color: ${BiFontColor.white};
+  font-weight: 700;Z
+  color: ${color.white};
 `;
 
 const StOverlay = styled.div`

--- a/src/components/modals/PostCreateModal.jsx
+++ b/src/components/modals/PostCreateModal.jsx
@@ -1,5 +1,180 @@
-const PostCreateModal = () => {
-  return <div>PostCreateModal</div>;
+import styled from 'styled-components';
+import { color } from '../../styles/color';
+import { fontSize } from '../../styles/fontSize';
+import { useRef, useState } from 'react';
+
+const PostCreateModal = ({ isOpen, close }) => {
+  if (!isOpen) {
+    return null; // isOpen이 false면 렌더링하지 않음
+  }
+  
+  const [imgPreview, setImagePreview] = useState(""); // img 파일이 imgPreview 상태에 Base64 문자열로 들어갈 것이기 때문에 기본값이 ""임
+  const imgRef = useRef(); //useRef는 컴포넌트 안에서 DOM 요소나 값을 직접 참조!! ==> useState()를 사용할 때와 달리 input태그의 값에 직접 접근할 수 있어 불필요한 리렌더링을 줄일 수 있음
+
+  const handleImgPreview = () => {
+    const file = imgRef.current.files[0]  // imgRef.current는 input요소를 참조 => files는 그 input에서 선택한 파일들 => files[0]는 선택된 첫 번째 파일(preview용)
+    const reader = new FileReader();  // FileReader 객체 생성 => new FileReader는 컴퓨터에게  "input에 들어가는 파일을 읽어서 JavaScript에서 사용할 수 있는 형태로 변환해줘!"라고 말하는 객체
+    reader.readAsDataURL(file);   // .readAsDataURL은 이제 읽는 방식을 "JavaScript에서 사용할 수 있는 형태인 Base64 형식으로 변환해줘!"라고 말하는 거
+    reader.onloadend = () => {    // 파일 읽기가 끝나면 실행
+      setImagePreview(reader.result);  // 변환된 데이터 URL을 imgFile 상태에 저장 => 상태관리를 하는 것!
+    };
+  };
+
+  return (
+    <StOverlay>
+      <StContainer>
+        <StWrapper>
+          <StForm>
+            <h2>모달창</h2>
+            <StCloseButton onClick={close}>닫기</StCloseButton>
+            <StInputWrapper>
+              <Stdiv>
+                <img src={imgPreview ? imgPreview : null} />
+                <label htmlFor="postImage">이미지 추가</label>
+                <input type="file" accept='image/*, video/*' id='postImage' onChange={handleImgPreview} ref={imgRef}/>
+              </Stdiv>
+              <StTextInputWrapper>
+                <StLabel>
+                  제목
+                  <input type="textarea" />
+                </StLabel>
+                <StLabel>
+                  내용
+                  <textarea name="" id=""></textarea>
+                </StLabel>
+                <StLabel>
+                  태그
+                  <input type="text" />
+                </StLabel>
+              </StTextInputWrapper>
+            </StInputWrapper>
+            <button type="submit">올리기</button>
+          </StForm>
+        </StWrapper>
+      </StContainer>
+
+    </StOverlay>
+  );
 };
 
 export default PostCreateModal;
+
+// ----------------------------------- styled-components 너무 많아 ㅠㅠㅠㅠㅠㅠ
+
+const flexCenter = `
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const StOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.5); /* 배경 어둡게 처리 */
+  ${flexCenter}
+`;
+
+const StContainer = styled.div`
+  max-width: 70vw; /* 모달창 최대 크기 설정 */
+  height: 90%;
+  flex-direction: column;
+  ${flexCenter};
+  background-color: ${color.white}; /* 모달창 배경색 */
+  border-radius: 10px;
+  position: relative; /* 위치 설정 */
+`;
+
+const StWrapper = styled.div`
+  width: 70vw;
+  height: 800px;
+  ${flexCenter};
+  border-radius: 10px;
+`;
+
+const StForm = styled.form`
+  width: 100%;
+  height: 100%;
+  ${flexCenter};
+  flex-direction: column;
+
+  button {
+    padding: 10px 15px;
+    background-color: ${color.main};
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+  }
+`;
+
+const StInputWrapper = styled.div`
+  width: 100%;
+  ${flexCenter};
+`;
+
+const Stdiv = styled.div`
+  width: 40%;
+  margin: 5%;
+  min-height: 500px;
+  ${flexCenter};
+  border: 5px dotted ${color.gray};
+  border-radius: 10px;
+  position: relative; /* 추가된 부분 */
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  label {
+    color: ${color.main};
+    font-size: ${fontSize.large};
+    font-weight: 700;
+    cursor: pointer;
+    display: ${({imgPreview}) => imgPreview? 'none' : 'block'} // imgPreview 값이 "true"이면 label display를 "none"으로 바꾸기
+  };
+
+  input {
+    display: none;
+  }
+`;
+
+const StTextInputWrapper = styled.div`
+  width: 50%;
+  height: 90%;
+  flex-direction: column;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  font-size: large;
+`;
+
+const StLabel = styled.label`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  font-weight: 700;
+
+  input {
+    width: 28vw;
+    border: 1px solid black;
+    border-radius: 10px;
+    padding: 10px;
+  }
+
+  textarea {
+    min-width: 30vw;
+    min-height: 15vh;
+  }
+`;
+
+const StCloseButton = styled.button`
+  position: absolute;
+  right: 10px;
+  top: 10px;
+`;
+
+// 보통은 branch 기능별로 만들어서 커밋푸시 하긴 한다.


### PR DESCRIPTION
### 관련 이슈
> 모달창 레이아웃 및 기본 기능 구현


### 작업 요약
> ✅ 모달창 레이아웃 구현 styled-components
         - 사진 업로드 + 미리보기
         - 제목/내용 작성란
         -  태그 작성란
         
✅ 모달창 기능 구현
-  모달창 열기/닫기 기능  =>  Home.jsx 파일에 적어서 PR한 코드 내부에는 없지만 개인적으로 가지고 있어 다음 PR추가할 예정
-  폼 제출 기능                  => handleSubmit() 함수로 폼 제출 시 alert("폼이 제출되었습니다!")가 실행됨
- 사진 미리보기 기능        => handleImgPreview() 함수로 리액트 훅인 useState()와 useRef를 활용함


### 리뷰 요구 사항
> 리뷰 예상 시간: 5 ~ 10분
> 모달창 코드 자체에서 수정해야 할 점이 있다면 알려주시길 부탁드립니다. (주석, 코드 문법 등등)
>


### 미리보기
> 프론트에서 디자인에 변경사항 또는 새로운 디자인을 머지하는 경우 이미지를 첨부합니다.
[모달창 열기 버튼은 임시적입니다!]
![PostCreateModal](https://github.com/user-attachments/assets/a03c3839-677f-47bf-b74c-8d97c3b374f2)
