### PR TITLE
Fix: 공통 레이아웃 적용 위치 수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,13 +1,7 @@
-import { GlobalStyle } from './styles/GlobalStyle';
 import Router from './shared/Router';
 
 const App = () => {
-  return (
-    <>
-      <GlobalStyle />
-      <Router />
-    </>
-  );
+  return <Router />;
 };
 
 export default App;

--- a/src/components/features/Home/PostCard.jsx
+++ b/src/components/features/Home/PostCard.jsx
@@ -1,7 +1,13 @@
 import styled from 'styled-components';
 
 const PostCard = () => {
-  return <StCardContainer>PostCard</StCardContainer>;
+  return (
+    <StCardContainer>
+      <StHeaderWrapper></StHeaderWrapper>
+      <StImgWrapper></StImgWrapper>
+      <StFooterWrapper></StFooterWrapper>
+    </StCardContainer>
+  );
 };
 
 export default PostCard;
@@ -10,4 +16,11 @@ const StCardContainer = styled.div`
   width: 90%;
   height: 700px;
   background-color: beige;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `;
+
+const StHeaderWrapper = styled.div``;
+const StImgWrapper = styled.div``;
+const StFooterWrapper = styled.div``;

--- a/src/components/features/Home/PostCard.jsx
+++ b/src/components/features/Home/PostCard.jsx
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+const PostCard = () => {
+  return <StCardContainer>PostCard</StCardContainer>;
+};
+
+export default PostCard;
+
+const StCardContainer = styled.div`
+  width: 90%;
+  height: 700px;
+  background-color: beige;
+`;

--- a/src/components/features/Login/LoginForm.jsx
+++ b/src/components/features/Login/LoginForm.jsx
@@ -65,7 +65,7 @@ const LoginForm = () => {
               value={userInfo.password}
               onChange={handleChange}
             />
-            <StSignButton>가입하기</StSignButton>
+            <StSignButton>로그인하기</StSignButton>
           </StLoginWrapper>
         </form>
         <StSignUpWrapper>

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -58,6 +58,8 @@ export default Header;
 /** styled component */
 const StContainer = styled.header`
   position: fixed;
+  width: 100%;
+  background-color: white;
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -57,6 +57,7 @@ export default Header;
 
 /** styled component */
 const StContainer = styled.header`
+  position: fixed;
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/src/components/layout/MainLayout.jsx
+++ b/src/components/layout/MainLayout.jsx
@@ -1,10 +1,11 @@
+import { Outlet } from 'react-router-dom';
 import { HeaderProvider } from '../../context/components/header/HeaderProvider';
 import { SidebarProvider } from '../../context/components/sidebar/SidebarProvider';
 import Header from './Header';
 import Sidebar from './SideBar';
 import styled from 'styled-components';
 
-const MainLayout = ({ children }) => {
+const MainLayout = () => {
   return (
     <StContainer>
       <HeaderProvider>
@@ -14,7 +15,9 @@ const MainLayout = ({ children }) => {
         <SidebarProvider>
           <Sidebar />
         </SidebarProvider>
-        <StContentWrapper>{children}</StContentWrapper>
+        <StContentWrapper>
+          <Outlet />
+        </StContentWrapper>
       </StMainContent>
     </StContainer>
   );

--- a/src/components/layout/MainLayout.jsx
+++ b/src/components/layout/MainLayout.jsx
@@ -11,14 +11,12 @@ const MainLayout = () => {
       <HeaderProvider>
         <Header />
       </HeaderProvider>
-      <StMainContent>
-        <SidebarProvider>
-          <Sidebar />
-        </SidebarProvider>
-        <StContentWrapper>
-          <Outlet />
-        </StContentWrapper>
-      </StMainContent>
+      <SidebarProvider>
+        <Sidebar />
+      </SidebarProvider>
+      <StContentWrapper>
+        <Outlet />
+      </StContentWrapper>
     </StContainer>
   );
 };
@@ -29,11 +27,6 @@ export default MainLayout;
 const StContainer = styled.div`
   display: flex;
   flex-direction: column;
-`;
-
-const StMainContent = styled.main`
-  display: flex;
-  flex: 1;
 `;
 
 const StContentWrapper = styled.div`

--- a/src/components/layout/SideBar.jsx
+++ b/src/components/layout/SideBar.jsx
@@ -52,6 +52,8 @@ const StContainer = styled.div`
   flex-direction: column;
   padding: 20px 10px;
   position: fixed;
+  top: 47px;
+
   transition: width 0.25s ease-in-out;
   overflow: hidden;
   height: 100%;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,17 +1,16 @@
 import Header from '../components/layout/Header';
 import Sidebar from '../components/layout/SideBar';
 import styled from 'styled-components';
+import { color } from '../styles/color';
 
 const Home = () => {
   return (
     <StContainer>
       <Header />
-      <StMainContent>
-        <Sidebar />
-        <StContentWrapper>
-          <div>Home</div>
-        </StContentWrapper>
-      </StMainContent>
+      <Sidebar />
+      <StMainWrapper>
+        <StContentWrapper></StContentWrapper>
+      </StMainWrapper>
     </StContainer>
   );
 };
@@ -22,13 +21,22 @@ export default Home;
 const StContainer = styled.div`
   display: flex;
   flex-direction: column;
+  min-height: 100vh;
+  background-color: #f5f5f5;
 `;
 
-const StMainContent = styled.main`
+const StMainWrapper = styled.div`
+  width: 100%;
   display: flex;
-  flex: 1;
+  flex-direction: column;
+  align-items: center;
 `;
 
 const StContentWrapper = styled.div`
-  padding: 10px;
+  width: 60%;
+  min-height: 100vh;
+  background-color: ${color.white};
+  display: flex;
+  align-items: center;
+  justify-content: center;
 `;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -2,6 +2,7 @@ import Header from '../components/layout/Header';
 import Sidebar from '../components/layout/SideBar';
 import styled from 'styled-components';
 import { color } from '../styles/color';
+import PostCard from '../components/features/Home/PostCard';
 
 const Home = () => {
   return (
@@ -9,7 +10,11 @@ const Home = () => {
       <Header />
       <Sidebar />
       <StMainWrapper>
-        <StContentWrapper></StContentWrapper>
+        <StContentWrapper>
+          <PostCard />
+          <PostCard />
+          <PostCard />
+        </StContentWrapper>
       </StMainWrapper>
     </StContainer>
   );
@@ -19,8 +24,6 @@ export default Home;
 
 /** styled component */
 const StContainer = styled.div`
-  display: flex;
-  flex-direction: column;
   min-height: 100vh;
   background-color: #f5f5f5;
 `;
@@ -37,6 +40,9 @@ const StContentWrapper = styled.div`
   min-height: 100vh;
   background-color: ${color.white};
   display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
   align-items: center;
-  justify-content: center;
+  padding-top: 90px;
+  gap: 40px;
 `;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -3,14 +3,15 @@ import Sidebar from '../components/layout/SideBar';
 import styled from 'styled-components';
 import { color } from '../styles/color';
 import PostCard from '../components/features/Home/PostCard';
+import { supabase } from '../services/supabaseClient';
+import { useEffect, useState } from 'react';
 
 const Home = () => {
   const [posts, setPosts] = useState([]);
 
-  // supabase - SELECT 함수 (getPost)
   const getPost = async () => {
     try {
-      const { data } = await supabase.from('posts').select();
+      const { data } = await supabase.from('posts').select('*');
       setPosts(data);
     } catch (error) {
       console.error(error);
@@ -19,12 +20,10 @@ const Home = () => {
 
   useEffect(() => {
     getPost();
-  }, []); // 초기 렌더링 시에만 데이터 fetch
+  }, []);
 
   return (
     <StContainer>
-      <Header />
-      <Sidebar />
       <StMainWrapper>
         <StContentWrapper>
           <PostCard />

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -69,8 +69,6 @@ const MyPage = () => {
 
   return (
     <>
-      <Header />
-      <SideBar />
       <StProfileContainer>
         <StProfileHeader>
           <StProfileImage src="" alt="" />

--- a/src/shared/Router.jsx
+++ b/src/shared/Router.jsx
@@ -5,6 +5,7 @@ import MyPage from '../pages/MyPage';
 import Search from '../pages/Search';
 import SignUp from '../pages/SignUp';
 import { useAuth } from '../context/auth/useAuth';
+import MainLayout from '../components/layout/MainLayout';
 
 const Router = () => {
   const { isLogin } = useAuth();
@@ -12,11 +13,13 @@ const Router = () => {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<Home />} />
+        <Route element={<MainLayout />}>
+          <Route path="/" element={<Home />} />
+          <Route path="/search" element={<Search />} />
+          <Route path="/mypage" element={<MyPage />} />
+        </Route>
         <Route path="/login" element={isLogin ? <Navigate to="/" /> : <Login />} />
         <Route path="/signup" element={isLogin ? <Navigate to="/" /> : <SignUp />} />
-        <Route path="/mypage" element={<MyPage />} />
-        <Route path="/search" element={<Search />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/styles/GlobalStyle.jsx
+++ b/src/styles/GlobalStyle.jsx
@@ -6,8 +6,6 @@ export const GlobalStyle = createGlobalStyle`
   ${reset};
 
   * {
-    margin: 0;
-    padding: 0;
     box-sizing: border-box;
   }
 `;


### PR DESCRIPTION
### 관련 이슈
--

### 작업 요약
기존의 dev 코드를 pull 해오고 메인페이지(Home) 작업을 하는 도중에 MainLayout이 Home에만 적용되어 있는 것을 확인하고, 적용 위치를 수정하였습니다.

**주요 변경사항**
📍 **MainLayout의 위치를 상위 컴포넌트인 Router로 수정**하였습니다.
로그인 페이지와 회원가입 페이지에서는 적용될 필요가 없어서 분리하였습니다.
📍 유지보수를 위하여 MainLayout에 children 대신 **Outlet을 적용**하였습니다.
📍 공통 레이아웃을 적용했기 때문에, **MyPage에 있는 사이드바와 헤더를 제거**하였습니다.
📍 GlobalStyle이 App.jsx와 man.jsx 모두에 적용되어 있어서 **App.jsx에 있는 스타일을 제거**하였습니다.

**기타 변경사항**
· 공통 레이아웃을 적용한 뒤에, Home 내용과 MyPage의 내용이 보이지 않아서 MainLayOut에 있는 컴포넌트를 하나 제거하였습니다.
· 로그인 페이지에 있는 "가입하기" 버튼명을 **"로그인하기"로 수정**하였습니다.
· Header을 고정시켜 두었습니다.
· Home에 PostCard 컴포넌트가 추가되었습니다.

### 리뷰 요구 사항
리뷰 예상 시간: 10분
공통 레이아웃(MainLayout)이 잘 적용되었는지 위주로 확인해주시면 감사하겠습니다.

### 미리보기
![공통레이아웃](https://github.com/user-attachments/assets/0e71d11b-9c36-4d6c-ae60-4b8cc38bef23)