### PR TITLE
Feat/post detail modal

### DIFF
--- a/src/components/modals/PostDetailModal.jsx
+++ b/src/components/modals/PostDetailModal.jsx
@@ -6,7 +6,7 @@ import { color } from '../../styles/color';
 import { useAuth } from '../../context/auth/useAuth';
 
 const PostDetailModal = ({ isDetailOpen, setIsDetailOpen, postId }) => {
-  const { isLogin } = useAuth();
+  const { isLogin, loginedUser } = useAuth();
 
   const [selectedPost, setSelectedPost] = useState(null);
   const [writerData, setWriterData] = useState(null);
@@ -117,10 +117,12 @@ const PostDetailModal = ({ isDetailOpen, setIsDetailOpen, postId }) => {
         <StContentsWrapper>
           <StHeader>
             <h3>{writerData.nick_name}</h3>
-            <StBtnWrapper>
-              <button>수정</button>
-              <button onClick={handleDeletePost}>삭제</button>
-            </StBtnWrapper>
+            {loginedUser.id === selectedPost.writer_id ? (
+              <StBtnWrapper>
+                <button>수정</button>
+                <button onClick={handleDeletePost}>삭제</button>
+              </StBtnWrapper>
+            ) : null}
           </StHeader>
           <StContents>
             <h3>{selectedPost.title}</h3>

--- a/src/components/modals/PostDetailModal.jsx
+++ b/src/components/modals/PostDetailModal.jsx
@@ -96,7 +96,7 @@ const PostDetailModal = ({ isDetailOpen, setIsDetailOpen, postId }) => {
     <StDetailModalContainer onClick={handleCloseDetailByOutside}>
       <StGrClose onClick={handleCloseDetail} />
       <StModalContentsContainer>
-        <StImgWrapper>{selectedPost.img}</StImgWrapper>
+        <StImgWrapper>{selectedPost.img ? <StPostImg src={selectedPost.img} alt="Post Image" /> : null}</StImgWrapper>
         <StContentsWrapper>
           <StHeader>
             <h3>{writerData.nick_name}</h3>
@@ -174,6 +174,11 @@ const StImgWrapper = styled.div`
   width: 50%;
   height: 100%;
   background-color: ${color.gray};
+`;
+
+const StPostImg = styled.img`
+  width: 100%;
+  height: 100%;
 `;
 
 const StContentsWrapper = styled.div`

--- a/src/components/modals/PostDetailModal.jsx
+++ b/src/components/modals/PostDetailModal.jsx
@@ -23,14 +23,27 @@ const PostDetailModal = ({ isDetailOpen, setIsDetailOpen, postId }) => {
   };
 
   const [selectedPost, setSelectedPost] = useState(null);
+  const [writerData, setWriterData] = useState(null);
+
   async function getPosts() {
     try {
-      const { data } = await supabase.from('posts').select().eq('id', postId);
-      if (data && data.length > 0) {
-        setSelectedPost(data[0]);
+      // posts
+      const { data: postData } = await supabase.from('posts').select('*').eq('id', postId);
+      if (postData?.length) {
+        setSelectedPost(postData[0]);
+      }
+
+      // userExtraData
+      const { data: userData } = await supabase
+        .from('userExtraData')
+        .select('nick_name')
+        .eq('user_id', postData[0].writer_id);
+
+      if (userData?.length) {
+        setWriterData(userData[0]);
       }
     } catch (error) {
-      throw new error();
+      console.error(error);
     }
   }
 
@@ -40,8 +53,8 @@ const PostDetailModal = ({ isDetailOpen, setIsDetailOpen, postId }) => {
     }
   }, [postId]);
 
-  // selectedPost가 없으면 렌더링을 방지
-  if (selectedPost === null) {
+  // state가 null이면 렌더링 방지
+  if (selectedPost === null || writerData === null) {
     return;
   }
 
@@ -60,7 +73,7 @@ const PostDetailModal = ({ isDetailOpen, setIsDetailOpen, postId }) => {
         <StImgWrapper>{selectedPost.img}</StImgWrapper>
         <StContentsWrapper>
           <StHeader>
-            <h3>{selectedPost.writer_id}</h3>
+            <h3>{writerData.nick_name}</h3>
             <StBtnWrapper>
               <button>수정</button>
               <button>삭제</button>

--- a/src/components/modals/PostDetailModal.jsx
+++ b/src/components/modals/PostDetailModal.jsx
@@ -1,5 +1,178 @@
-const PostDetailModal = () => {
-  return <div>PostDetailModal</div>;
+import { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { supabase } from '../../services/supabaseClient';
+import { GrClose } from 'react-icons/gr';
+import { color } from '../../styles/color';
+
+const PostDetailModal = ({ isDetailOpen, setIsDetailOpen, postId }) => {
+  // isDetailOpen이 false일 경우, 모달 숨기기
+  if (!isDetailOpen) {
+    return null;
+  }
+
+  // 모달 닫기 핸들러
+  const handleCloseDetail = () => {
+    setIsDetailOpen(false);
+  };
+
+  // 모달 콘텐츠 외부를 클릭하면 모달 닫기
+  const handleCloseDetailByOutside = (e) => {
+    if (e.target === e.currentTarget) {
+      handleCloseDetail();
+    }
+  };
+
+  const [selectedPost, setSelectedPost] = useState(null);
+  async function getPosts() {
+    try {
+      const { data } = await supabase.from('posts').select().eq('id', postId);
+      if (data && data.length > 0) {
+        setSelectedPost(data[0]);
+      }
+    } catch (error) {
+      throw new error();
+    }
+  }
+
+  useEffect(() => {
+    if (postId) {
+      getPosts();
+    }
+  }, [postId]);
+
+  // selectedPost가 없으면 렌더링을 방지
+  if (selectedPost === null) {
+    return;
+  }
+
+  // 작성일 처리
+  const date = new Date(selectedPost.created_at);
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  const hours = String(date.getUTCHours()).padStart(2, '0');
+  const minutes = String(date.getUTCMinutes()).padStart(2, '0');
+
+  return (
+    <StDetailModalContainer onClick={handleCloseDetailByOutside}>
+      <StGrClose onClick={handleCloseDetail} />
+      <StModalContentsContainer>
+        <StImgWrapper>{selectedPost.img}</StImgWrapper>
+        <StContentsWrapper>
+          <StHeader>
+            <h3>{selectedPost.writer_id}</h3>
+            <StBtnWrapper>
+              <button>수정</button>
+              <button>삭제</button>
+            </StBtnWrapper>
+          </StHeader>
+          <StContents>
+            <h3>{selectedPost.title}</h3>
+            <p>{selectedPost.content}</p>
+            <p>{`${year}년 ${month}월 ${day}일 ${hours}:${minutes}`}</p>
+            <p>댓글작성자 : 댓글 내용</p>
+          </StContents>
+          <StInteraction>
+            <div>좋아요</div>
+            <StCommentsForm>
+              <StInput placeholder="댓글 달기..." />
+              <button type="submit">업로드</button>
+            </StCommentsForm>
+          </StInteraction>
+        </StContentsWrapper>
+      </StModalContentsContainer>
+    </StDetailModalContainer>
+  );
 };
 
 export default PostDetailModal;
+
+// Styled-components
+const StGrClose = styled(GrClose)`
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  font-size: 24px;
+  cursor: pointer;
+`;
+
+const StDetailModalContainer = styled.div`
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 9999;
+`;
+
+const StModalContentsContainer = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  width: 1200px;
+  height: 600px;
+  background-color: ${color.white};
+  border: 1px solid ${color.gray};
+  border-radius: 20px;
+  padding: 20px;
+`;
+
+const StImgWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  width: 50%;
+  height: 100%;
+  background-color: ${color.gray};
+`;
+
+const StContentsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+  justify-content: space-between;
+  margin-left: 15px;
+  padding: 20px;
+  width: 50%;
+  background-color: ${color.gray};
+`;
+
+const StHeader = styled.div`
+  border: 1px solid ${color.black};
+  padding: 20px;
+  display: flex;
+  justify-content: space-between;
+`;
+
+const StBtnWrapper = styled.div`
+  display: flex;
+  gap: 5px;
+`;
+
+const StContents = styled.div`
+  border: 1px solid ${color.black};
+  padding: 20px;
+  height: 50%;
+`;
+
+const StInteraction = styled.div`
+  border: 1px solid ${color.black};
+  padding: 20px;
+  height: 20%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+const StCommentsForm = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const StInput = styled.input`
+  width: 85%;
+`;

--- a/src/components/modals/PostDetailModal.jsx
+++ b/src/components/modals/PostDetailModal.jsx
@@ -117,7 +117,7 @@ const PostDetailModal = ({ isDetailOpen, setIsDetailOpen, postId }) => {
         <StContentsWrapper>
           <StHeader>
             <h3>{writerData.nick_name}</h3>
-            {loginedUser.id === selectedPost.writer_id ? (
+            {loginedUser && loginedUser.id === selectedPost.writer_id ? (
               <StBtnWrapper>
                 <button>수정</button>
                 <button onClick={handleDeletePost}>삭제</button>

--- a/src/components/modals/PostDetailModal.jsx
+++ b/src/components/modals/PostDetailModal.jsx
@@ -3,8 +3,22 @@ import styled from 'styled-components';
 import { supabase } from '../../services/supabaseClient';
 import { GrClose } from 'react-icons/gr';
 import { color } from '../../styles/color';
+import { useAuth } from '../../context/auth/useAuth';
 
 const PostDetailModal = ({ isDetailOpen, setIsDetailOpen, postId }) => {
+  const { isLogin } = useAuth();
+
+  const [selectedPost, setSelectedPost] = useState(null);
+  const [writerData, setWriterData] = useState(null);
+  const [comments, setComments] = useState([]);
+  const [newComment, setNewComment] = useState('');
+
+  useEffect(() => {
+    if (postId) {
+      getPosts();
+    }
+  }, [postId]);
+
   // isDetailOpen이 false일 경우, 모달 숨기기
   if (!isDetailOpen) {
     return null;
@@ -21,11 +35,6 @@ const PostDetailModal = ({ isDetailOpen, setIsDetailOpen, postId }) => {
       handleCloseDetail();
     }
   };
-
-  const [selectedPost, setSelectedPost] = useState(null);
-  const [writerData, setWriterData] = useState(null);
-  const [comments, setComments] = useState([]);
-  const [newComment, setNewComment] = useState('');
 
   async function getPosts() {
     try {
@@ -52,12 +61,6 @@ const PostDetailModal = ({ isDetailOpen, setIsDetailOpen, postId }) => {
     }
   }
 
-  useEffect(() => {
-    if (postId) {
-      getPosts();
-    }
-  }, [postId]);
-
   // state가 null이면 렌더링 방지
   if (selectedPost === null || writerData === null || comments === null) {
     return;
@@ -75,6 +78,10 @@ const PostDetailModal = ({ isDetailOpen, setIsDetailOpen, postId }) => {
   const handleUploadComment = async (e) => {
     e.preventDefault();
 
+    if (!isLogin) {
+      alert('[Notification] 댓글을 추가하려면 로그인이 필요합니다.');
+      return;
+    }
     if (!newComment.trim()) {
       alert('[Notification] 댓글 내용을 입력하세요.');
       return;
@@ -92,6 +99,16 @@ const PostDetailModal = ({ isDetailOpen, setIsDetailOpen, postId }) => {
     }
   };
 
+  // 게시글 삭제
+  const handleDeletePost = async () => {
+    // if(selectedPost.writer_id === )
+    // try {
+    //   const { data } = await supabase.from('posts').delete().match({ id: postId });
+    // } catch (error) {
+    //   console.error(error);
+    // }
+  };
+
   return (
     <StDetailModalContainer onClick={handleCloseDetailByOutside}>
       <StGrClose onClick={handleCloseDetail} />
@@ -102,7 +119,7 @@ const PostDetailModal = ({ isDetailOpen, setIsDetailOpen, postId }) => {
             <h3>{writerData.nick_name}</h3>
             <StBtnWrapper>
               <button>수정</button>
-              <button>삭제</button>
+              <button onClick={handleDeletePost}>삭제</button>
             </StBtnWrapper>
           </StHeader>
           <StContents>

--- a/src/components/modals/PostDetailModal.jsx
+++ b/src/components/modals/PostDetailModal.jsx
@@ -24,6 +24,7 @@ const PostDetailModal = ({ isDetailOpen, setIsDetailOpen, postId }) => {
 
   const [selectedPost, setSelectedPost] = useState(null);
   const [writerData, setWriterData] = useState(null);
+  const [comments, setComments] = useState(null);
 
   async function getPosts() {
     try {
@@ -38,9 +39,14 @@ const PostDetailModal = ({ isDetailOpen, setIsDetailOpen, postId }) => {
         .from('userExtraData')
         .select('nick_name')
         .eq('user_id', postData[0].writer_id);
-
       if (userData?.length) {
         setWriterData(userData[0]);
+      }
+
+      // // comments
+      const { data: commentsData } = await supabase.from('comments').select('*').eq('post_id', postData[0].id);
+      if (commentsData?.length) {
+        setComments(commentsData);
       }
     } catch (error) {
       console.error(error);
@@ -54,7 +60,7 @@ const PostDetailModal = ({ isDetailOpen, setIsDetailOpen, postId }) => {
   }, [postId]);
 
   // state가 null이면 렌더링 방지
-  if (selectedPost === null || writerData === null) {
+  if (selectedPost === null || writerData === null || comments === null) {
     return;
   }
 
@@ -83,7 +89,9 @@ const PostDetailModal = ({ isDetailOpen, setIsDetailOpen, postId }) => {
             <h3>{selectedPost.title}</h3>
             <p>{selectedPost.content}</p>
             <p>{`${year}년 ${month}월 ${day}일 ${hours}:${minutes}`}</p>
-            <p>댓글작성자 : 댓글 내용</p>
+            {comments.map((comment) => (
+              <p key={comment.id}>{comment.contents}</p>
+            ))}
           </StContents>
           <StInteraction>
             <div>좋아요</div>

--- a/src/context/auth/AuthProvider.jsx
+++ b/src/context/auth/AuthProvider.jsx
@@ -4,18 +4,21 @@ import { AuthContext } from './AuthContext';
 
 export const AuthProvider = ({ children }) => {
   const [isLogin, setIsLogin] = useState(false);
+  const [loginedUser, setLoginedUser] = useState(null);
 
   useEffect(() => {
     supabase.auth.onAuthStateChange((_, session) => {
       if (session) {
         setIsLogin(true);
+        setLoginedUser(session.user);
       } else {
         setIsLogin(false);
+        setLoginedUser(null);
       }
     });
   });
 
-  const value = { isLogin };
+  const value = { isLogin, loginedUser };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -31,10 +31,11 @@ const Home = () => {
   return (
     <MainLayout>
       {posts.map((post) => (
-        <div style={{ border: '1px solid black' }} key={post.id}>
+        <div style={{ border: '1px solid black' }} key={post.id} onClick={() => handleOpenDetail(post.id)}>
           <p>{post.title}</p>
         </div>
       ))}
+      <PostDetailModal isDetailOpen={isDetailOpen} setIsDetailOpen={setIsDetailOpen} postId={postId} />
     </MainLayout>
   );
 };

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -3,9 +3,12 @@ import Sidebar from '../components/layout/SideBar';
 import styled from 'styled-components';
 import { supabase } from '../services/supabaseClient';
 import { useEffect, useState } from 'react';
+import PostDetailModal from '../components/modals/PostDetailModal';
 
 const Home = () => {
   const [posts, setPosts] = useState([]);
+  const [isDetailOpen, setIsDetailOpen] = useState(false);
+  const [postId, setPostId] = useState(); // 디테일 핸들러 props
 
   // supabase - SELECT 함수 (getPost)
   const getPost = async () => {
@@ -21,6 +24,12 @@ const Home = () => {
     getPost();
   }, []); // 초기 렌더링 시에만 데이터 fetch
 
+  // 디테일 열기 핸들러
+  const handleOpenDetail = (postId) => {
+    setIsDetailOpen(true);
+    setPostId(postId);
+  };
+
   return (
     <StContainer>
       <Header />
@@ -29,11 +38,12 @@ const Home = () => {
         <StContentWrapper>
           <StPostWrapper>
             {posts.map((post) => (
-              <div style={{ border: '1px solid black' }} key={post.id}>
+              <div style={{ border: '1px solid black' }} key={post.id} onClick={() => handleOpenDetail(post.id)}>
                 <p>{post.title}</p>
               </div>
             ))}
           </StPostWrapper>
+          <PostDetailModal isDetailOpen={isDetailOpen} setIsDetailOpen={setIsDetailOpen} postId={postId} />
         </StContentWrapper>
       </StMainContent>
     </StContainer>


### PR DESCRIPTION
### 관련 이슈
> PostDetailModal 기능 구현 사항 Update
> 로그인된 사용자 정보를 전역 상태로 추가: `AuthProvider.jsx`

### 작업 요약
> DB 연동, 상세보기 기능 구현:
☑️ 이미지, 작성자 닉네임, 댓글 표시 기능 추가
☑️ 로그인/유저 권한에 따른 조건부 렌더링 적용
> Home 컴포넌트에 모달 오픈 로직 추가
☑️ 게시글 클릭 시 상세 모달 띄우는 기능, prop- drilling (리팩토링 전)
> 로그인 정보 상태 추가: `AuthProvider.jsx`
☑️ 로그인된 사용자 정보를 전역 상태로 추가
☑️ `PostDetailModal` 내 유저 정보에 따른 조건부 렌더링 적용 (댓글 작성 및 게시글 수정/삭제 버튼 표시)

### 리뷰 요구 사항
> 리뷰 예상 시간: 약 15-20분
> AuthProvider.jsx` 내 `loginedUser` 전역 상태 추가 관련, 다른 컴포넌트에서도 현재 로그인 한 유저정보가 필요하지 않을까 싶어 임의로 추가하였습니다. 해당 부분 검토하여 주시고, 혹시 로그인된 유저 정보가 전역적으로 불필요하다면 PostDetailModal 내에서만 사용하는 것으로 수정 조치 하겠습니다. 자유로운 의견 부탁드립니다.

### 미리보기
https://github.com/user-attachments/assets/3a7c6435-6c88-49b1-bc36-929d26322408
