### PR TITLE
Feat/search

### DIFF
--- a/src/components/features/Common/SearchBar.jsx
+++ b/src/components/features/Common/SearchBar.jsx
@@ -1,33 +1,53 @@
 import styled from 'styled-components';
+import { FaSearch } from 'react-icons/fa';
 
 // 각 element에서 value가 독립적으로 동작
 const SearchBar = ({ style, value, setValue }) => {
   return (
-    <SearchContainer>
-      <SearchInput
-        type="text"
-        placeholder="검색"
-        style={style}
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-      />
-    </SearchContainer>
+    <StContainer>
+      <StSearchInputWrapper>
+        <StIconWrapper>
+          <FaSearch />
+        </StIconWrapper>
+        <StSearchInput
+          type="text"
+          placeholder="검색"
+          style={style}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+        />
+      </StSearchInputWrapper>
+    </StContainer>
   );
 };
 
 export default SearchBar;
 
-const SearchContainer = styled.div`
+const StContainer = styled.div`
   display: flex;
   justify-content: left;
   align-items: center;
   padding: 15px;
 `;
 
+const StSearchInputWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  position: relative;
+`;
+
+const StIconWrapper = styled.div`
+  position: absolute;
+  left: 15px;
+  color: #999;
+  font-size: 18px;
+`;
+
 // 외부에서 전달된 style 적용
-const SearchInput = styled.input`
+const StSearchInput = styled.input`
   width: ${(props) => props.style?.width || '100%'};
-  padding: ${(props) => props.style?.padding || '9px 15px'};
+  padding: ${(props) => props.style?.padding || '10px 10px 10px 40px'};
   font-size: ${(props) => props.style?.fontSize || '12px'};
   border: ${(props) => props.style?.border || '2px solid #ccc'};
   border-radius: ${(props) => props.style?.borderRadius || '30px'};

--- a/src/components/features/Common/SearchBar.jsx
+++ b/src/components/features/Common/SearchBar.jsx
@@ -1,0 +1,41 @@
+import styled from 'styled-components';
+
+// 각 element에서 value가 독립적으로 동작
+const SearchBar = ({ style, value, setValue }) => {
+  return (
+    <SearchContainer>
+      <SearchInput
+        type="text"
+        placeholder="검색"
+        style={style}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    </SearchContainer>
+  );
+};
+
+export default SearchBar;
+
+const SearchContainer = styled.div`
+  display: flex;
+  justify-content: left;
+  align-items: center;
+  padding: 15px;
+`;
+
+// 외부에서 전달된 style 적용
+const SearchInput = styled.input`
+  width: ${(props) => props.style?.width || '100%'};
+  padding: ${(props) => props.style?.padding || '9px 15px'};
+  font-size: ${(props) => props.style?.fontSize || '12px'};
+  border: ${(props) => props.style?.border || '2px solid #ccc'};
+  border-radius: ${(props) => props.style?.borderRadius || '30px'};
+  background: ${(props) => props.style?.background || '#f8f8f8'};
+  outline: none;
+  box-shadow: ${(props) => props.style?.boxShadow || '0px 2px 5px rgba(0, 0, 0, 0.1)'};
+
+  &:focus {
+    border-color: ${(props) => props.style?.focusBorderColor || '#007bff'};
+  }
+`;

--- a/src/components/features/Common/SearchBar.jsx
+++ b/src/components/features/Common/SearchBar.jsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { FaSearch } from 'react-icons/fa';
+import { fontSize } from '../../../styles/fontSize';
 
 // 각 element에서 value가 독립적으로 동작
 const SearchBar = ({ style, value, setValue }) => {
@@ -41,14 +42,14 @@ const StIconWrapper = styled.div`
   position: absolute;
   left: 15px;
   color: #999;
-  font-size: 18px;
+  font-size: ${fontSize.medium};
 `;
 
 // 외부에서 전달된 style 적용
 const StSearchInput = styled.input`
   width: ${(props) => props.style?.width || '100%'};
   padding: ${(props) => props.style?.padding || '10px 10px 10px 40px'};
-  font-size: ${(props) => props.style?.fontSize || '12px'};
+  font-size: ${(props) => props.style?.fontSize || fontSize.medium};
   border: ${(props) => props.style?.border || '2px solid #ccc'};
   border-radius: ${(props) => props.style?.borderRadius || '30px'};
   background: ${(props) => props.style?.background || '#f8f8f8'};

--- a/src/components/features/Search/SearchForm.jsx
+++ b/src/components/features/Search/SearchForm.jsx
@@ -1,0 +1,5 @@
+const SearchForm = () => {
+  return <div>SearchForm</div>;
+};
+
+export default SearchForm;

--- a/src/components/features/Search/SearchForm.jsx
+++ b/src/components/features/Search/SearchForm.jsx
@@ -1,18 +1,26 @@
+import { useState } from 'react';
 import styled from 'styled-components';
 import SearchBar from '../Common/SearchBar';
+import { fontSize } from '../../../styles/fontSize';
 
 const SearchForm = () => {
   const searchBarStyle = {
-    fontSize: '18px'
+    fontSize: fontSize.medium
   };
+
+  const [activeTab, setActiveTab] = useState(0);
+
+  const tabs = ['제목', '계정', '태그'];
 
   return (
     <StContainer>
       <SearchBar style={searchBarStyle} />
       <StTabMenu>
-        <StTab>제목</StTab>
-        <StTab>계정</StTab>
-        <StTab>태그</StTab>
+        {tabs.map((tab, index) => (
+          <StTab key={index} isActive={activeTab === index} onClick={() => setActiveTab(index)}>
+            {tab}
+          </StTab>
+        ))}
       </StTabMenu>
     </StContainer>
   );
@@ -27,17 +35,20 @@ const StContainer = styled.div`
 
 const StTabMenu = styled.div`
   display: flex;
+  border-bottom: 1px solid #ddd;
 `;
 
 const StTab = styled.button`
-  padding: 8px 16px;
+  padding: 10px 16px;
   border: none;
-  background: #f1f1f1;
-  border-radius: 5px;
+  background: transparent;
   cursor: pointer;
   font-weight: bold;
+  font-size: ${fontSize.medium};
+  color: ${(props) => (props.isActive ? '#000' : '#999')};
+  border-bottom: ${(props) => (props.isActive ? '2px solid #000' : 'none')};
 
   &:hover {
-    background: #e0e0e0;
+    color: #000;
   }
 `;

--- a/src/components/features/Search/SearchForm.jsx
+++ b/src/components/features/Search/SearchForm.jsx
@@ -1,5 +1,44 @@
+import styled from 'styled-components';
+import SearchBar from '../Common/SearchBar';
+
 const SearchForm = () => {
-  return <div>SearchForm</div>;
+  const searchBarStyle = {
+    padding: '12px 20px',
+    fontSize: '18px'
+  };
+
+  return (
+    <StContainer>
+      <SearchBar style={searchBarStyle} />
+      <StTabMenu>
+        <StTab>제목</StTab>
+        <StTab>계정</StTab>
+        <StTab>태그</StTab>
+      </StTabMenu>
+    </StContainer>
+  );
 };
 
 export default SearchForm;
+
+const StContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const StTabMenu = styled.div`
+  display: flex;
+`;
+
+const StTab = styled.button`
+  padding: 8px 16px;
+  border: none;
+  background: #f1f1f1;
+  border-radius: 5px;
+  cursor: pointer;
+  font-weight: bold;
+
+  &:hover {
+    background: #e0e0e0;
+  }
+`;

--- a/src/components/features/Search/SearchForm.jsx
+++ b/src/components/features/Search/SearchForm.jsx
@@ -38,7 +38,11 @@ const StTabMenu = styled.div`
   border-bottom: 1px solid #ddd;
 `;
 
-const StTab = styled.button`
+const StTab = styled.button.withConfig({
+  // isActive 속성은 직접 만든 것이므로 HTML 태그가 속성을 인식하지 못해
+  // 에러를 유발한다. shouldForwardProp를 사용해 DOM에 전달하지 않도록 한다.
+  shouldForwardProp: (prop) => prop !== 'isActive'
+})`
   padding: 10px 16px;
   border: none;
   background: transparent;

--- a/src/components/features/Search/SearchForm.jsx
+++ b/src/components/features/Search/SearchForm.jsx
@@ -47,13 +47,13 @@ const SearchForm = () => {
           </StTab>
         ))}
       </StTabMenu>
-      <StFeedGrid>
+      <StFeedWrapper>
         {posts.map((post) => (
           <StFeedItem key={post.id}>
-            <img src={post.image_url} alt={post.title} />
+            <img src={post.img} alt={post.title} />
           </StFeedItem>
         ))}
-      </StFeedGrid>
+      </StFeedWrapper>
     </StContainer>
   );
 };
@@ -89,44 +89,43 @@ const StTab = styled.button.withConfig({
   }
 `;
 
-const StFeedGrid = styled.div`
-  display: grid;
-  grid-template-columns: repeat(1, 1fr);
-  gap: 16px;
+const StFeedWrapper = styled.div`
+  column-count: 1;
+  column-gap: 16px;
   width: 100%;
   padding: 20px;
 
   @media (min-width: 600px) {
-    grid-template-columns: repeat(2, 1fr);
+    column-count: 2;
   }
 
   @media (min-width: 900px) {
-    grid-template-columns: repeat(3, 1fr);
+    column-count: 3;
   }
 
   @media (min-width: 1200px) {
-    grid-template-columns: repeat(4, 1fr);
+    column-count: 4;
   }
 
   @media (min-width: 1500px) {
-    grid-template-columns: repeat(5, 1fr);
+    column-count: 5;
   }
 
   @media (min-width: 1800px) {
-    grid-template-columns: repeat(6, 1fr);
+    column-count: 6;
   }
 `;
 
 const StFeedItem = styled.div`
   width: 100%;
+  margin-bottom: 16px;
   border-radius: 10px;
   overflow: hidden;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-  position: relative;
 
   img {
     width: 100%;
-    height: auto; // 세로 크기는 이미지 비율에 맞게 자동 조정
+    height: auto;
     object-fit: cover;
     border-radius: 10px;
   }

--- a/src/components/features/Search/SearchForm.jsx
+++ b/src/components/features/Search/SearchForm.jsx
@@ -6,11 +6,16 @@ import { supabase } from '../../../services/supabaseClient';
 
 const SearchForm = () => {
   const [activeTab, setActiveTab] = useState(0);
-  const [_, setPosts] = useState([]);
+  const [posts, setPosts] = useState([]);
+  const [searchValue, setSearchValue] = useState('');
 
-  const getPost = async () => {
+  const getPost = async (searchQuery = '') => {
     try {
-      const { data } = await supabase.from('posts').select('*');
+      const { data } = await supabase
+        .from('posts')
+        .select('*')
+        .ilike('title', `%${searchQuery}%`) // 제목에 검색어 포함된 데이터 가져오기
+        .order('created_at', { ascending: false }); // 최신순 정렬
       setPosts(data);
     } catch (error) {
       console.error(error);
@@ -18,8 +23,14 @@ const SearchForm = () => {
   };
 
   useEffect(() => {
-    getPost();
-  }, []);
+    getPost(searchValue);
+  }, [searchValue]);
+
+  const handleTabChange = (index) => {
+    setActiveTab(index);
+    // 탭 클릭 시 해당 탭에 맞는 데이터 가져오기
+    getPost(searchValue);
+  };
 
   const searchBarStyle = {
     fontSize: fontSize.medium
@@ -28,14 +39,21 @@ const SearchForm = () => {
 
   return (
     <StContainer>
-      <SearchBar style={searchBarStyle} />
+      <SearchBar style={searchBarStyle} value={searchValue} setValue={setSearchValue} />
       <StTabMenu>
         {tabs.map((tab, index) => (
-          <StTab key={index} isActive={activeTab === index} onClick={() => setActiveTab(index)}>
+          <StTab key={index} isActive={activeTab === index} onClick={() => handleTabChange(index)}>
             {tab}
           </StTab>
         ))}
       </StTabMenu>
+      <StFeedGrid>
+        {posts.map((post) => (
+          <StFeedItem key={post.id}>
+            <img src={post.image_url} alt={post.title} />
+          </StFeedItem>
+        ))}
+      </StFeedGrid>
     </StContainer>
   );
 };
@@ -68,5 +86,48 @@ const StTab = styled.button.withConfig({
 
   &:hover {
     color: #000;
+  }
+`;
+
+const StFeedGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(1, 1fr);
+  gap: 16px;
+  width: 100%;
+  padding: 20px;
+
+  @media (min-width: 600px) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @media (min-width: 900px) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  @media (min-width: 1200px) {
+    grid-template-columns: repeat(4, 1fr);
+  }
+
+  @media (min-width: 1500px) {
+    grid-template-columns: repeat(5, 1fr);
+  }
+
+  @media (min-width: 1800px) {
+    grid-template-columns: repeat(6, 1fr);
+  }
+`;
+
+const StFeedItem = styled.div`
+  width: 100%;
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  position: relative;
+
+  img {
+    width: 100%;
+    height: auto; // 세로 크기는 이미지 비율에 맞게 자동 조정
+    object-fit: cover;
+    border-radius: 10px;
   }
 `;

--- a/src/components/features/Search/SearchForm.jsx
+++ b/src/components/features/Search/SearchForm.jsx
@@ -3,7 +3,6 @@ import SearchBar from '../Common/SearchBar';
 
 const SearchForm = () => {
   const searchBarStyle = {
-    padding: '12px 20px',
     fontSize: '18px'
   };
 

--- a/src/components/features/Search/SearchForm.jsx
+++ b/src/components/features/Search/SearchForm.jsx
@@ -1,15 +1,29 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import SearchBar from '../Common/SearchBar';
 import { fontSize } from '../../../styles/fontSize';
+import { supabase } from '../../../services/supabaseClient';
 
 const SearchForm = () => {
+  const [activeTab, setActiveTab] = useState(0);
+  const [_, setPosts] = useState([]);
+
+  const getPost = async () => {
+    try {
+      const { data } = await supabase.from('posts').select('*');
+      setPosts(data);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    getPost();
+  }, []);
+
   const searchBarStyle = {
     fontSize: fontSize.medium
   };
-
-  const [activeTab, setActiveTab] = useState(0);
-
   const tabs = ['제목', '계정', '태그'];
 
   return (

--- a/src/components/layout/MainLayout.jsx
+++ b/src/components/layout/MainLayout.jsx
@@ -9,10 +9,14 @@ const MainLayout = () => {
   return (
     <StContainer>
       <HeaderProvider>
-        <Header />
+        <StHeader>
+          <Header />
+        </StHeader>
       </HeaderProvider>
       <SidebarProvider>
-        <Sidebar />
+        <StSidebar>
+          <Sidebar />
+        </StSidebar>
       </SidebarProvider>
       <StContentWrapper>
         <Outlet />
@@ -25,10 +29,24 @@ export default MainLayout;
 
 /** styled component */
 const StContainer = styled.div`
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-rows: 50px 1fr;
+  grid-template-columns: 70px 1fr;
+  height: 100vh;
 `;
 
-const StContentWrapper = styled.div`
-  padding: 10px;
+const StHeader = styled.div`
+  grid-row: 1;
+  grid-column: span 2;
+`;
+
+const StSidebar = styled.aside`
+  grid-row: 2;
+  grid-column: 1;
+`;
+
+const StContentWrapper = styled.main`
+  grid-row: 2;
+  grid-column: 2;
+  overflow-y: auto;
 `;

--- a/src/components/layout/MainLayout.jsx
+++ b/src/components/layout/MainLayout.jsx
@@ -43,6 +43,7 @@ const StHeader = styled.div`
 const StSidebar = styled.aside`
   grid-row: 2;
   grid-column: 1;
+  z-index: 100;
 `;
 
 const StContentWrapper = styled.main`

--- a/src/components/layout/MainLayout.jsx
+++ b/src/components/layout/MainLayout.jsx
@@ -38,6 +38,7 @@ const StContainer = styled.div`
 const StHeader = styled.div`
   grid-row: 1;
   grid-column: span 2;
+  z-index: 100;
 `;
 
 const StSidebar = styled.aside`

--- a/src/pages/Search.jsx
+++ b/src/pages/Search.jsx
@@ -1,5 +1,7 @@
+import SearchForm from '../components/features/Search/SearchForm';
+
 const Search = () => {
-  return <div>Search</div>;
+  return <SearchForm />;
 };
 
 export default Search;


### PR DESCRIPTION
### 관련 이슈
search 페이지 기본 ui 구현, data query 구현, 검색 기능 구현

### 작업 요약
✅ Search 페이지의 기본 UI 구현 완료
- 검색바는 재사용 가능하도록 공통 컴포넌트로 외부에 두었습니다.(SearchBar.jsx)
- 탐색 방식별로 tab을 두었고, 인스타그램처럼 탭 디자인을 하였습니다.
- 피드 아이템은 창 크기에 맞게 반응형으로 두었고, 모두 동일한 너비를 갖는 기준으로 이미지 해상도에 맞게 높이를 갖게 하였습니다. 실제 image url을 넣고 테스트가 필요합니다.

✅ db로부터 전체 데이터를 가져와 피드 아이템으로 표시
- Home.jsx에서 사용하는 fetch 방식 그대로인데, 중복 코드이므로 추후 한곳에서 관리하도록 수정하는게 좋아보입니다.

✅ 검색을 통한 게시물 필터링
- 검색바에 입력한 글자가 변경될 때마다 필터링이 이루어져 보이는 게시물들이 바뀝니다.

✅ MainLayout을 flex에서 grid 방식으로 수정, 기타 ui 개선 작업 진행

### 리뷰 요구 사항
- 검색바(SearchBar.jsx)는 다른 분들도 편하게 사용하실 수 있게 컴포넌트를 따로 선언했으니, 확인해보시고 앞으로 사용하셔도 좋을 거 같고, 추가할 속성들도 알려주시면 감사하겠습니다!

### 미리보기
(소리가 섞여 들어갔어요.. ㅠㅠ 음소거하고 재생해주세요)
https://github.com/user-attachments/assets/8392d741-b1a2-4a23-967e-2221660a3e15


