### PR TITLE
Feat/search detail

### DIFF
--- a/src/components/features/Search/SearchForm.jsx
+++ b/src/components/features/Search/SearchForm.jsx
@@ -220,7 +220,7 @@ const StNoResultMessage = styled.div`
   color: #721c24;
   padding: 16px;
   border-radius: 8px;
-  font-size: 16px;
+  font-size: ${fontSize.medium};
   font-weight: bold;
   text-align: center;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
@@ -237,7 +237,7 @@ const StSpinner = styled.div`
   left: 50%;
   transform: translate(-50%, -50%);
   text-align: center;
-  font-size: 18px;
+  font-size: ${fontSize.large};
   font-weight: bold;
   padding: 20px;
   color: #333;

--- a/src/components/features/Search/SearchForm.jsx
+++ b/src/components/features/Search/SearchForm.jsx
@@ -3,11 +3,15 @@ import styled from 'styled-components';
 import SearchBar from '../Common/SearchBar';
 import { fontSize } from '../../../styles/fontSize';
 import { supabase } from '../../../services/supabaseClient';
+import SimplePostCard from './SimplePostCard';
+import PostDetailModal from '../../modals/PostDetailModal';
 
 const SearchForm = () => {
   const [activeTab, setActiveTab] = useState(0);
   const [searchValue, setSearchValue] = useState('');
   const [isLoading, setIsLoading] = useState(true); // 초기 로딩 상태를 true로 설정
+  const [isDetailOpen, setIsDetailOpen] = useState(false);
+  const [postId, setPostId] = useState(); // 디테일 핸들러 props
 
   const [posts, setPosts] = useState([]);
   const [users, setUsers] = useState([]);
@@ -56,6 +60,12 @@ const SearchForm = () => {
     updateItem(searchValue, index);
   };
 
+  // 디테일 모달 열기 핸들러
+  const handleOpenDetail = (postId) => {
+    setIsDetailOpen(true);
+    setPostId(postId);
+  };
+
   const searchBarStyle = {
     fontSize: fontSize.medium
   };
@@ -78,11 +88,7 @@ const SearchForm = () => {
           posts.length === 0 ? (
             renderNoResultsMessage()
           ) : (
-            posts.map((post) => (
-              <StFeedItem key={post.id}>
-                <img src={post.img} alt={post.title} />
-              </StFeedItem>
-            ))
+            posts.map((post) => <SimplePostCard key={post.id} post={post} onClick={() => handleOpenDetail(post.id)} />)
           )
         ) : activeTab === 1 ? (
           users.length === 0 ? (
@@ -97,6 +103,9 @@ const SearchForm = () => {
           )
         ) : (
           <div>태그 검색은 아직 구현되지 않았습니다.</div>
+        )}
+        {isDetailOpen && (
+          <PostDetailModal isDetailOpen={isDetailOpen} setIsDetailOpen={setIsDetailOpen} postId={postId} />
         )}
       </StFeedWrapper>
     </StContainer>
@@ -161,21 +170,21 @@ const StFeedWrapper = styled.div`
   }
 `;
 
-const StFeedItem = styled.div`
-  width: 100%;
-  margin-bottom: 16px;
-  border-radius: 10px;
-  overflow: hidden;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+// const StFeedItem = styled.div`
+//   width: 100%;
+//   margin-bottom: 16px;
+//   border-radius: 10px;
+//   overflow: hidden;
+//   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 
-  img {
-    width: 100%;
-    height: auto;
-    min-height: 100px;
-    object-fit: cover;
-    border-radius: 10px;
-  }
-`;
+//   img {
+//     width: 100%;
+//     height: auto;
+//     min-height: 100px;
+//     object-fit: cover;
+//     border-radius: 10px;
+//   }
+// `;
 
 const StUserItem = styled.div`
   display: flex;

--- a/src/components/features/Search/SimplePostCard.jsx
+++ b/src/components/features/Search/SimplePostCard.jsx
@@ -50,6 +50,7 @@ const StCardContainer = styled.div`
   border-radius: 10px;
   overflow: hidden;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
 
   img {
     width: 100%;

--- a/src/components/features/Search/SimplePostCard.jsx
+++ b/src/components/features/Search/SimplePostCard.jsx
@@ -1,0 +1,86 @@
+import { useEffect } from 'react';
+import styled from 'styled-components';
+import { supabase } from '../../../services/supabaseClient';
+import { useNavigate } from 'react-router-dom';
+
+const SimplePostCard = ({ post, onClick }) => {
+  const { writer_id } = post || null;
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!writer_id) return;
+
+    const getUserNickname = async () => {
+      try {
+        const { error } = await supabase.from('userExtraData').select('nick_name').eq('user_id', writer_id).single();
+
+        if (error) {
+          throw error;
+        }
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    getUserNickname();
+  }, [writer_id]);
+
+  return (
+    <StCardContainer onClick={onClick}>
+      <StHeaderWrapper>
+        <StWrapper
+          onClick={(e) => {
+            e.stopPropagation();
+            navigate(`/profile/${writer_id}`);
+          }}
+        ></StWrapper>
+      </StHeaderWrapper>
+      <StImgWrapper>
+        <StPostImg src={post.img} alt="게시글 이미지" />
+      </StImgWrapper>
+    </StCardContainer>
+  );
+};
+
+export default SimplePostCard;
+
+const StCardContainer = styled.div`
+  width: 100%;
+  margin-bottom: 16px;
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+
+  img {
+    width: 100%;
+    height: auto;
+    min-height: 100px;
+    object-fit: cover;
+    border-radius: 10px;
+  }
+`;
+
+const StHeaderWrapper = styled.div`
+  flex: 1;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const StWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+`;
+
+const StImgWrapper = styled.div`
+  flex: 10;
+  width: 100%;
+  overflow: hidden;
+`;
+
+const StPostImg = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;

--- a/src/components/modals/PostDetailModal.jsx
+++ b/src/components/modals/PostDetailModal.jsx
@@ -192,7 +192,7 @@ const PostDetailModal = ({ isDetailOpen, setIsDetailOpen, postId }) => {
             {comments.map((comment) => (
               <StCommentWrapper key={comment.id}>
                 <p>{comment.contents}</p>
-                {loginedUser.id === comment.writer_id ? (
+                {loginedUser?.id === comment.writer_id ? (
                   <StBtn onClick={() => handleDeleteComment(comment.id)}>삭제</StBtn>
                 ) : null}
               </StCommentWrapper>


### PR DESCRIPTION
관련 이슈
search 페이지에서 피드 클릭시 detail 페이지 열리도록 수정

작업 요약
✅ 기존 PostCard 컴포넌트 재활용이 힘들어, SimplePostCard로 경량화된 컴포넌트 생성하여
기존 Card Item 표시 대체

✅ 비로그인 상태에서 피드를 클릭하여 모달을 표시할 때 죽는 에러 처리

✅ card 형태 표시 디자인 업그레이드

리뷰 요구 사항

미리보기
빠른 다음 작업을 위해 스킵하였습니다..