### PR TITLE
Design: 웹사이트명 수정 및 공통 폰트 pretendard 적용

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,15 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      rel="stylesheet"
+      as="style"
+      crossorigin
+      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css"
+    />
     <title>Vite + React</title>
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,13 @@
       crossorigin
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css"
     />
-    <title>Vite + React</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Arvo:ital,wght@0,400;0,700;1,400;1,700&display=swap"
+      rel="stylesheet"
+    />
+    <title>cattale</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { fontSize } from '../../styles/fontSize';
 import { StCenterWrapper } from '../../styles/GlobalStyle';
 import { FaRegBell, FaUserCircle } from 'react-icons/fa';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useHeader } from '../../context/components/header/useHeader';
 import { useAuth } from '../../context/auth/useAuth';
 import { color } from '../../styles/color';
@@ -14,7 +14,7 @@ const Header = () => {
 
   return (
     <StContainer>
-      <StLogo>CATTALE</StLogo>
+      <StLogo to={'/'}>CATTALE</StLogo>
       <StIconsWrapper>
         <StIconWrapper>
           <StBellIcon size={30} />
@@ -50,9 +50,11 @@ const StContainer = styled.header`
   border-bottom: 1px solid #e0e0e0;
 `;
 
-const StLogo = styled.div`
+const StLogo = styled(Link)`
   font-family: 'Arvo', serif;
   font-weight: 500;
+  color: ${color.black};
+  text-decoration: none;
 `;
 
 const StIconsWrapper = styled(StCenterWrapper)`

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -5,6 +5,7 @@ import { FaRegBell, FaUserCircle } from 'react-icons/fa';
 import { useNavigate } from 'react-router-dom';
 import { useHeader } from '../../context/components/header/useHeader';
 import { useAuth } from '../../context/auth/useAuth';
+import { color } from '../../styles/color';
 
 const Header = () => {
   const { isLoginOpen, setIsLoginOpen, loginModalRef, handleAuthAction } = useHeader();
@@ -13,7 +14,7 @@ const Header = () => {
 
   return (
     <StContainer>
-      <StLogo>로고</StLogo>
+      <StLogo>CATTALE</StLogo>
       <StIconsWrapper>
         <StIconWrapper>
           <StBellIcon size={30} />
@@ -50,7 +51,8 @@ const StContainer = styled.header`
 `;
 
 const StLogo = styled.div`
-  font-weight: bold;
+  font-family: 'Arvo', serif;
+  font-weight: 500;
 `;
 
 const StIconsWrapper = styled(StCenterWrapper)`

--- a/src/styles/GlobalStyle.jsx
+++ b/src/styles/GlobalStyle.jsx
@@ -8,6 +8,9 @@ export const GlobalStyle = createGlobalStyle`
   * {
     box-sizing: border-box;
   }
+  body {
+    font-family: "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
+  }
 `;
 
 export const StCenterWrapper = styled.div`


### PR DESCRIPTION
### 관련 이슈
--

### 작업 요약
✅ 웹사이트명 "CatTale"로 수정하였습니다.
✅ 로고 누르면 Home으로 이동할 수 있게 Link 태그로 구현하였습니다.
✅ GlobalStyle에 공통 폰트 pretendard로 적용해두었습니다. 

### 리뷰 요구 사항
리뷰 예상 시간: 5분

### 미리보기
다음 작업을 위해 생략합니다!
